### PR TITLE
Adjust Collectability retrieval

### DIFF
--- a/Artisan/CraftingLogic/CurrentCraft.cs
+++ b/Artisan/CraftingLogic/CurrentCraft.cs
@@ -240,8 +240,8 @@ namespace Artisan.CraftingLogic
                 CurrentStep = Convert.ToInt32(cs.NodeText.ToString());
                 HQLiteral = hql.NodeText.ToString();
                 CollectabilityLow = collectLow.NodeText.ToString().GetNumbers();
-                CollectabilityMid = collectMid.NodeText.ToString().GetNumbers();
-                CollectabilityHigh = collectHigh.NodeText.ToString().GetNumbers();
+                CollectabilityMid = collectMid.NodeText.ToString().GetNumbers(def: CollectabilityLow);
+                CollectabilityHigh = collectHigh.NodeText.ToString().GetNumbers(def: CollectabilityMid);
 
                 return true;
 

--- a/Artisan/RawInformation/HelperExtensions.cs
+++ b/Artisan/RawInformation/HelperExtensions.cs
@@ -9,13 +9,13 @@ namespace Artisan.RawInformation
 {
     internal static class HelperExtensions
     {
-        public static string GetNumbers(this string input)
+        public static string GetNumbers(this string input, string def = "")
         {
-            if (input == null) return "";
-            if (input.Length == 0) return "";
+            if (input == null) return def;
+            if (input.Length == 0) return def;
 
             var numbers = new string(input.Where(c => char.IsDigit(c)).ToArray());
-            return numbers;
+            return !String.IsNullOrEmpty(numbers) ? numbers : def;
         }
 
         public static string GetLast(this string source, int tail_length)


### PR DESCRIPTION
This is to accommodate for collectable crafts with less than 3 tiers As the game only uses the first nodes when necessary, Artisan will crash when targeting High Collectability when the node is not in use

This is based on a patch on code I originally created in early May, I have adjusted it work with recent refractors that have now also have included the feature on the main codebase. Adding a default or fallback to the GetNumbers as an optional argument seemed like a logical solution otherwise other ideas would have put more operations after retrieving empty nodes to account for this error