### PR TITLE
Disable window open sound in RecipeWindowUI

### DIFF
--- a/Artisan/UI/RecipeWindowUI.cs
+++ b/Artisan/UI/RecipeWindowUI.cs
@@ -29,6 +29,7 @@ namespace Artisan
             IsOpen = true;
             ShowCloseButton = false;
             RespectCloseHotkey = false;
+            DisableWindowSounds = true;
             this.SizeConstraints = new WindowSizeConstraints()
             {
                 MaximumSize = new Vector2(0, 0),


### PR DESCRIPTION
Dalamud added open/close sound effects for plugin windows a while ago (Dalamud Settings -> Look & Feel -> Enable sound effects for plugin windows) and every time the game starts it plays the open window sound because the sound effects are not disabled for `RecipeWindowUI` which is opened when the plugin loads (no DrawConditions).
This PR disables the sounds in that window. 🙂