### PR TITLE
Feat/limit universalis to datacenter

### DIFF
--- a/Artisan/Configuration.cs
+++ b/Artisan/Configuration.cs
@@ -117,6 +117,7 @@ namespace Artisan
         public bool DefaultHQCrafts = false;
 
         public bool UseUniversalis = false;
+        public bool UniversalisDataCenter = false;
 
         public int SolverCollectibleMode = 3;
         public ItemFilter ShowItemsV1 { get; set; } = ItemFilter.All;

--- a/Artisan/RawInformation/ExtendedIngredient.cs
+++ b/Artisan/RawInformation/ExtendedIngredient.cs
@@ -91,7 +91,11 @@ namespace Artisan.RawInformation
             UsedInMaterialsList = materials.Where(x => LuminaSheets.RecipeSheet.Values.Any(y => y.ItemResult.Row == x.Key && y.UnkData5.Any(z => z.ItemIngredient == Data.RowId))).ToDictionary(x => x.Key, x => x.Value);
 
             if (P.Config.UseUniversalis)
-            MarketboardData =  P.UniversalsisClient.GetRegionData(itemId);
+            {
+                MarketboardData = (P.Config.UniversalisDataCenter)
+                    ? P.UniversalsisClient.GetDataCenterData(itemId)
+                    : P.UniversalsisClient.GetRegionData(itemId);
+            }
         }
 
         public virtual event EventHandler<bool>? OnRemainingChange;

--- a/Artisan/UI/PluginUI.cs
+++ b/Artisan/UI/PluginUI.cs
@@ -775,6 +775,9 @@ namespace Artisan.UI
 
                     if (ImGui.Checkbox($"Fetch Prices from Universalis (Slower Load Time)", ref P.Config.UseUniversalis))
                         P.Config.Save();
+
+                    if (ImGui.Checkbox($"Fetch Prices for current Data Center only", ref P.Config.UniversalisDataCenter))
+                        P.Config.Save();
                 }
 
                 ImGui.Unindent();

--- a/Artisan/Universalis/DataCenters.cs
+++ b/Artisan/Universalis/DataCenters.cs
@@ -26,18 +26,42 @@ namespace Artisan.Universalis
             猫小胖 = { 1192, 1183, 1180, 1186, 1201, 1068, 1064, 1187 },
             한국 = { 2075, 2076, 2077, 2078, 2080 };
 
+        public static readonly Dictionary<string, uint[]> AllDataCenters = new()
+            {
+                { "Elemental", Elemental },
+                { "Gaia", Gaia },
+                { "Mana", Mana},
+                { "Aether", Aether },
+                { "Primal", Primal },
+                { "Chaos", Chaos  },
+                { "Light", Light },
+                { "Crystal", Crystal },
+                { "Materia", Materia },
+                { "Meteor", Meteor },
+                { "Dynamis", Dynamis },
+                { "陆行鸟", 陆行鸟 },
+                { "莫古力", 莫古力 },
+                { "猫小胖", 猫小胖 },
+                { "한국", 한국 },
+            };
+
         public static uint[]? GetDataCenterByWorld(uint world)
         {
-            foreach (var region in Regions.AllRegions)
+            foreach (var worlds in AllDataCenters.Values)
             {
-                foreach (var dc in region.Values)
-                {
-                    foreach (var worlds in dc)
-                    {
-                        if (worlds.Contains(world))
-                            return worlds;
-                    }
-                }
+                if (worlds.Contains(world))
+                    return worlds;
+            }
+
+            return null;
+        }
+
+        public static string? GetDataCenterNameByWorld(uint world)
+        {
+            foreach (var worlds in AllDataCenters.Values)
+            {
+                if (worlds.Contains(world))
+                    return AllDataCenters.FindKeysByValue(worlds).First();
             }
 
             return null;

--- a/Artisan/Universalis/UniversalisClient.cs
+++ b/Artisan/Universalis/UniversalisClient.cs
@@ -29,7 +29,7 @@ namespace Artisan.Universalis
             return marketBoardFromAPI;
         }
 
-        public MarketboardData GetRegionData(ulong itemId)
+        public MarketboardData? GetRegionData(ulong itemId)
         {
             var world = Svc.ClientState.LocalPlayer?.CurrentWorld.Id;
             if (world == null)

--- a/Artisan/Universalis/UniversalisClient.cs
+++ b/Artisan/Universalis/UniversalisClient.cs
@@ -43,6 +43,19 @@ namespace Artisan.Universalis
             return GetMarketBoard(region, itemId);
         }
 
+        public MarketboardData? GetDataCenterData(ulong itemId)
+        {
+            var world = Svc.ClientState.LocalPlayer?.CurrentWorld.Id;
+            if (world == null)
+                return null;
+
+            var datacenter = DataCenters.GetDataCenterNameByWorld(world.Value);
+            if (datacenter == null)
+                return null;
+
+            return GetMarketBoard(datacenter, itemId);
+        }
+
         public void Dispose()
         {
             this.httpClient.Dispose();


### PR DESCRIPTION
Adds a boolean option to limit Universalis queries to the player's current Data Center. Defaults to `false`.

Universalis accepts the [data center as an argument](https://docs.universalis.app/#market-board-current-data) on the route already in use by Artisan, so there's no new endpoints added for this.

__Testing locally__
<details>
  <summary>
new config option
</summary>

   ![image](https://github.com/PunishXIV/Artisan/assets/2792750/7e496eb6-7bae-48d7-bb17-32197956c121)
</details>
<details>
  <summary>ingredient list when the option is `false`
  </summary>

  ![image](https://github.com/PunishXIV/Artisan/assets/2792750/c96959ff-d155-43e4-81b9-dca0c50a2781)
</details>
<details>
  <summary>ingredient list when the option is `true`.
  </summary>

   ![image](https://github.com/PunishXIV/Artisan/assets/2792750/5244af7d-18f6-4bce-9f6e-10c702090758)
</details>

__Other stuff__
Happy to change any names or formatting, lmk. C# is not a language I use regularly, so apologies in advance if I overlooked some language specific nuance or convenience.

I did not fix it, but the client name has a type in this definition https://github.com/PunishXIV/Artisan/blob/02db30494700db02794a9c04f0132badf2ae893f/Artisan/Artisan.cs#L118
```diff
- UniversalsisClient  
+ UniversalisClient 
```

closes PunishXIV/Artisan/issues/39