### PR TITLE
A bunch of fixes

### DIFF
--- a/Artisan/Autocraft/Endurance.cs
+++ b/Artisan/Autocraft/Endurance.cs
@@ -1,5 +1,6 @@
 ﻿using Artisan.CraftingLists;
 using Artisan.GameInterop;
+using Artisan.GameInterop.CSExt;
 using Artisan.RawInformation;
 using Artisan.RawInformation.Character;
 using Artisan.Sounds;
@@ -219,9 +220,16 @@ namespace Artisan.Autocraft
                         if (addon->SelectedRecipeName is null)
                             return;
 
+                        var rd = RecipeNoteRecipeData.Ptr();
+                        if (rd == null || rd->Recipes == null)
+                        {
+                            RecipeID = 0;
+                            return;
+                        }
+
                         if (addon->AtkUnitBase.UldManager.NodeList[49]->IsVisible)
                         {
-                            RecipeID = RecipeNote.Instance()->RecipeList->SelectedRecipe->RecipeId;
+                            RecipeID = rd->Recipes[rd->SelectedIndex].RecipeId;
                         }
                         Array.Clear(SetIngredients);
 
@@ -385,7 +393,7 @@ namespace Artisan.Autocraft
                             P.TM.Enqueue(() => CraftingListFunctions.RecipeWindowOpen(), "EnduranceCheckRecipeWindow");
                             P.TM.DelayNext("EnduranceThrottle", 100);
 
-                            P.TM.Enqueue(() => { if (!CraftingListFunctions.HasItemsForRecipe((uint)RecipeID)) { if (P.Config.PlaySoundFinishEndurance) Sounds.SoundPlayer.PlaySound(); Enable = false; } }, "EnduranceStartCraft");
+                            P.TM.Enqueue(() => { if (!CraftingListFunctions.HasItemsForRecipe(RecipeID)) { if (P.Config.PlaySoundFinishEndurance) Sounds.SoundPlayer.PlaySound(); Enable = false; } }, "EnduranceStartCraft");
                             if (P.Config.CraftingX)
                                 P.TM.Enqueue(() => Operations.QuickSynthItem(P.Config.CraftX));
                             else
@@ -400,7 +408,7 @@ namespace Artisan.Autocraft
                                 P.TM.Enqueue(() => CraftingListFunctions.SetIngredients(SetIngredients), "EnduranceSetIngredients");
 
                             P.TM.DelayNext("EnduranceThrottle", 100);
-                            P.TM.Enqueue(() => { if (CraftingListFunctions.HasItemsForRecipe((uint)RecipeID)) Operations.RepeatActualCraft(); else { if (P.Config.PlaySoundFinishEndurance) Sounds.SoundPlayer.PlaySound(); Enable = false; } }, "EnduranceStartCraft");
+                            P.TM.Enqueue(() => { if (CraftingListFunctions.HasItemsForRecipe(RecipeID)) return Operations.RepeatActualCraft(); else { if (P.Config.PlaySoundFinishEndurance) Sounds.SoundPlayer.PlaySound(); Enable = false; return true; } }, "EnduranceStartCraft");
                         }
                     }
                     else
@@ -418,7 +426,7 @@ namespace Artisan.Autocraft
                                 else
                                 {
                                     if (DebugTab.Debug) Svc.Log.Debug($"Opening recipe {RecipeID}");
-                                    AgentRecipeNote.Instance()->OpenRecipeByRecipeIdInternal((uint)RecipeID);
+                                    AgentRecipeNote.Instance()->OpenRecipeByRecipeIdInternal(RecipeID);
                                 }
                             }
                         }

--- a/Artisan/CraftingList/CraftingList.cs
+++ b/Artisan/CraftingList/CraftingList.cs
@@ -490,7 +490,7 @@ namespace Artisan.CraftingLists
 
                             CLTM.Enqueue(() => SetIngredients(), "SettingIngredients");
                             CLTM.DelayNext("CraftListDelay", (int)(P.Config.ListCraftThrottle * 1000));
-                            CLTM.Enqueue(() => { Operations.RepeatActualCraft(); }, "ListCraft");
+                            CLTM.Enqueue(() => Operations.RepeatActualCraft(), "ListCraft");
 
                             return;
                         }

--- a/Artisan/CraftingLogic/Simulator.cs
+++ b/Artisan/CraftingLogic/Simulator.cs
@@ -54,7 +54,7 @@ public static class Simulator
         {
             if (next.Quality != step.Quality)
                 ++next.IQStacks;
-            if (action is Skills.PreciseTouch or Skills.PreparatoryTouch or Skills.Reflect or Skills.TrainedEye)
+            if (action is Skills.PreciseTouch or Skills.PreparatoryTouch or Skills.Reflect)
                 ++next.IQStacks;
             if (next.IQStacks > 10)
                 next.IQStacks = 10;
@@ -82,8 +82,6 @@ public static class Simulator
 
         if (step.FinalAppraisalLeft > 0 && next.Progress >= craft.CraftProgress)
             next.Progress = craft.CraftProgress - 1;
-        if (action == Skills.TrainedEye)
-            next.Quality = craft.CraftQualityMax;
 
         next.RemainingCP = step.RemainingCP - GetCPCost(step, action);
         if (action == Skills.TricksOfTrade) // can't fail
@@ -279,6 +277,9 @@ public static class Simulator
 
     public static int CalculateQuality(CraftState craft, StepState step, Skills action)
     {
+        if (action == Skills.TrainedEye)
+            return craft.CraftQualityMax;
+
         int potency = action switch
         {
             Skills.BasicTouch => 100,

--- a/Artisan/GameInterop/Operations.cs
+++ b/Artisan/GameInterop/Operations.cs
@@ -115,19 +115,15 @@ public static unsafe class Operations
         }
     }
 
-    public unsafe static void RepeatActualCraft()
+    public unsafe static bool RepeatActualCraft()
     {
-        try
-        {
-            if (GenericHelpers.TryGetAddonByName<AddonRecipeNote>("RecipeNote", out var recipenote))
-            {
-                ClickRecipeNote.Using(new nint(&recipenote->AtkUnitBase)).Synthesize();
-                Endurance.Tasks.Clear();
-            }
-        }
-        catch (Exception ex)
-        {
-            Svc.Log.Error(ex, "RepeatActualCraft");
-        }
+        var addon = (AddonRecipeNote*)Svc.GameGui.GetAddonByName("RecipeNote");
+        if (addon == null)
+            return false;
+
+        Svc.Log.Debug($"Starting actual craft");
+        Callback.Fire(&addon->AtkUnitBase, true, 8);
+        Endurance.Tasks.Clear();
+        return true;
     }
 }

--- a/Artisan/RawInformation/HelperExtensions.cs
+++ b/Artisan/RawInformation/HelperExtensions.cs
@@ -30,7 +30,7 @@ namespace Artisan.RawInformation
                 Error = (sender, args) => { success = false; args.ErrorContext.Handled = true; },
                 MissingMemberHandling = MissingMemberHandling.Error
             };
-            result = JsonConvert.DeserializeObject<T>(@this, settings);
+            result = JsonConvert.DeserializeObject<T>(@this, settings)!;
             return success;
         }
     }


### PR DESCRIPTION
- Endurance.DrawRecipeData now handles non-fully-loaded recipenote without exception
- endurance and crafting lists now call eventhandler for buttons directly rather than emulating button clicks (which are hooked)
- sim now handles trained eye correctly
- all 3 buttons are now hooked and do full precraft logic (changing gear etc)