### PR TITLE
Added List Renaming

### DIFF
--- a/Artisan/UI/ListEditor.cs
+++ b/Artisan/UI/ListEditor.cs
@@ -992,6 +992,7 @@ internal class ListEditor : Window, IDisposable
         if (ImGui.InputText("###RenameList", ref listName, 200))
         {
             SelectedList.Name = listName;
+            P.Config.Save();
         }
         ImGuiComponents.HelpMarker("This list name.");
 

--- a/Artisan/UI/ListEditor.cs
+++ b/Artisan/UI/ListEditor.cs
@@ -988,6 +988,13 @@ internal class ListEditor : Window, IDisposable
     private void DrawListSettings()
     {
         ImGui.BeginChild("ListSettings", ImGui.GetContentRegionAvail(), false);
+        var listName = SelectedList.Name;
+        if (ImGui.InputText("###RenameList", ref listName, 200))
+        {
+            SelectedList.Name = listName;
+        }
+        ImGuiComponents.HelpMarker("This list name.");
+
         var skipIfEnough = SelectedList.SkipIfEnough;
         if (ImGui.Checkbox("Skip Crafting Unnecessary Materials", ref skipIfEnough))
         {


### PR DESCRIPTION
In the list settings, added the possibility to rename a list.
This is a very simple addition that I always wanted to add because I often want to rename my lists and I can't without creating a new one. At least, I didn't find how to do it.
Now you simply have to go into the List Settings and change the name with the input.