### PR TITLE
Optimize Recipe Lookup

### DIFF
--- a/Artisan/RawInformation/LuminaSheets.cs
+++ b/Artisan/RawInformation/LuminaSheets.cs
@@ -14,6 +14,8 @@ namespace Artisan.RawInformation
 
         public static Dictionary<uint, Recipe>? RecipeSheet;
 
+        public static ILookup<string, Recipe>? recipeLookup;
+
         public static Dictionary<uint, GatheringItem>? GatheringItemSheet;
 
         public static Dictionary<uint, SpearfishingItem>? SpearfishingItemSheet;
@@ -64,6 +66,10 @@ namespace Artisan.RawInformation
                 .OrderBy(x => x.RecipeLevelTable.Value.ClassJobLevel)
                 .ThenBy(x => x.ItemResult.Value.Name.ToDalamudString().ToString())
                 .ToDictionary(x => x.RowId, x => x);
+
+            // Preprocess the recipe data into a lookup table (ILookup) for faster access.
+            recipeLookup = LuminaSheets.RecipeSheet.Values
+                .ToLookup(x => x.ItemResult.Value.Name.ToDalamudString().ToString());
 
             GatheringItemSheet = Svc.Data?.GetExcelSheet<GatheringItem>()?
                 .Where(x => x.GatheringItemLevel.Value.GatheringItemLevel > 0)

--- a/Artisan/UI/ListEditor.cs
+++ b/Artisan/UI/ListEditor.cs
@@ -1132,16 +1132,17 @@ internal class ListEditor : Window, IDisposable
             ImGui.TextWrapped("This item cannot be quick synthed.");
         }
 
-        if (LuminaSheets.RecipeSheet.Values
-                .Where(x => x.ItemResult.Value.Name.ToDalamudString().ToString() == selectedListItem.NameOfRecipe()).Count() > 1)
+        // Retrieve the list of recipes matching the selected recipe name from the preprocessed lookup table.
+        var matchingRecipes = LuminaSheets.recipeLookup[selectedListItem.NameOfRecipe()].ToList();
+
+        if (matchingRecipes.Count > 1)
         {
             var pre = $"{LuminaSheets.ClassJobSheet[recipe.CraftType.RowId + 8].Abbreviation.ToString()}";
             ImGui.TextWrapped("Switch crafted job");
             ImGuiEx.SetNextItemFullWidth(-30);
             if (ImGui.BeginCombo("###SwitchJobCombo", pre))
             {
-                foreach (var altJob in LuminaSheets.RecipeSheet.Values.Where(
-                             x => x.ItemResult.Value.Name.ToDalamudString().ToString() == selectedListItem.NameOfRecipe()))
+                foreach (var altJob in matchingRecipes)
                 {
                     var altJ = $"{LuminaSheets.ClassJobSheet[altJob.CraftType.RowId + 8].Abbreviation.ToString()}";
                     if (ImGui.Selectable($"{altJ}"))

--- a/Artisan/UI/ListEditor.cs
+++ b/Artisan/UI/ListEditor.cs
@@ -1111,7 +1111,7 @@ internal class ListEditor : Window, IDisposable
             ImGui.SameLine();
             if (ImGui.Button("Apply To all###QuickSynthAll"))
             {
-                foreach (var r in SelectedList.Recipes)
+                foreach (var r in SelectedList.Recipes.Where(n => LuminaSheets.RecipeSheet[n.ID].CanQuickSynth))
                 {
                     if (r.ListItemOptions == null)
                     { r.ListItemOptions = new(); }


### PR DESCRIPTION
Addressing massive performance lost when viewing list editor. Replaced LINQ `.Where` with preprocessed lookup to improve performance and avoid repeated filtering of the recipe sheet.