### PR TITLE
Don't block any branch other than `release`

### DIFF
--- a/Artisan/Artisan.cs
+++ b/Artisan/Artisan.cs
@@ -86,32 +86,29 @@ public unsafe class Artisan : IDalamudPlugin
         Svc.PluginInterface.UiBuilder.OpenMainUi += DrawConfigUI;
 
         Style = StyleModel.Deserialize("DS1H4sIAAAAAAAACq1YS3PbNhD+Kx2ePR6AeJG+xXYbH+KOJ3bHbW60REusaFGlKOXhyX/v4rEACEqumlY+ECD32/cuFn7NquyCnpOz7Cm7eM1+zy5yvfnDPL+fZTP4at7MHVntyMi5MGTwBLJn+HqWLZB46Ygbx64C5kQv/nRo8xXQ3AhZZRdCv2jdhxdHxUeqrJO3Ftslb5l5u/Fa2rfEvP0LWBkBPQiSerF1Cg7wApBn2c5wOMv2juNn9/zieH09aP63g+Kqyr1mI91mHdj5mj3UX4bEG+b5yT0fzRPoNeF1s62e2np+EuCxWc+7z5cLr1SuuCBlkTvdqBCEKmaQxCHJeZmXnFKlgMHVsmnnEZ5IyXMiFUfjwt6yCHvDSitx1212m4gHV0QURY4saMEYl6Q4rsRl18/rPuCZQ+rFJxeARwyAJb5fVmD4NBaJEK3eL331UscuAgflOcY0J5zLUioHpHmhCC0lCuSBwU23r3sfF/0N0wKdoxcGFqHezYZmHypJIkgiSCJIalc8NEM7Utb6ErWlwngt9aUoFRWSB3wilRUl5SRwISUFvhJt9lvDrMgLIjgLzK66tq0228j0H+R3W693l1UfmUd9kqA79MKn9/2sB9lPI8hbofb073vdh1BbQYRgqKzfGbTfTWVqHmnMOcXUpI6BXhzGJjEQCNULmy4x9GpZz1a3Vb8KqaIDz4RPVGZin6dlZPKDSS29baAyRqYfzVGnr0ekaaowTbEw9MLjLnfD0GGT1unHSSlKr2lRyqLA2qU5ESovi6m+lkvqYiZ1/ygxyqrgjDKF8Yr2lp1pd4R7dokhvOBUQk37TCVKQbX4TMVtyuymruKWJCURVEofClYWbNpWCQfFifDwsWnYyXXS8ZxDOI+H0uLToPzrhKg3VV8N3amt1dP/t5goW/E85pg2pB8N8sd623yr3/dNOPYVstELg9cLA8zFCJKapQpEYkPVi9CMA/L/Uv8hrk1hmg9WKKMQXyIxnGFrm6i06MkhBHlIiQ8rI0xx4k/rsLWBsWpbTmmhqFIypcvUHTRgQ859V/bbKaPf1s/dbBcfD0R6NnCWwg/dS3lB4MfQMSrnCY9EK8qEw9uUl4YdHjRQRVFTuu5mq2a9uOvrfVOH0SDHqtXxMjDfi1RA/fyyGb7G5y5KdJg8EnTXdsOHZl1vQyJJQrlCQTDsEBi80HdhO+VwrEP48hwdTRp202yHbgGzhRfu03/UCA4gjglDd44mUT2D2i4UH9coSy8mfjEYN54NfbcOOIZnn15M7YqAH5rFEmdl3eJ8r0N5E9zH0fz71nQQyN+1/zSP6yR2A/l93dazoY6n5DdyiumWc91Xi+u+2zxU/aI+Jipq2QD5tdrfgO3t2P5jcqz9gLEXAEjgFHzcMJUgr5uXyDQsNSxZtCvX81s3r1qLOw0EztC3ORiEs4vssu9W9fqn2263HqpmncFF016PqklGjh1kjQ2NUyUJH08mcIk9gSrqn+jg0XFoqeqTrmDPwQv+PDEr6wl3oljaxcRSRTCyMc/lJJ/lAcnNhMr3WWZ+ES3exrXE+HJ2yNOrowkb97A2cExdXcrYjaFToVDfGSMqnCaDa0pi/vzNMyLG/wQEyzmzfhx7KAwJUn93Fz6v5shD8B+DRAG4Oh+QHYapovAd3/OEQzuiDSdE4c8wjJHh7iiBFFozvP3+NxT8RWGlEQAA")!;
-        if (!DalamudInfo.IsOnStaging())
-        {
-            CraftingProcessor.Setup();
-            ConsumableChecker.Init();
-            Endurance.Init();
-            IPC.IPC.Init();
-            RetainerInfo.Init();
-            CraftingListContextMenu.Init();
-            UniversalsisClient = new();
+        CraftingProcessor.Setup();
+        ConsumableChecker.Init();
+        Endurance.Init();
+        IPC.IPC.Init();
+        RetainerInfo.Init();
+        CraftingListContextMenu.Init();
+        UniversalsisClient = new();
 
-            EnduranceCraftWatcher.Setup();
-            ws.AddWindow(new RecipeWindowUI());
-            ws.AddWindow(new ProcessingWindow());
-            ws.AddWindow(new QuestHelper());
-            cw = new();
-            ws.AddWindow(cw);
+        EnduranceCraftWatcher.Setup();
+        ws.AddWindow(new RecipeWindowUI());
+        ws.AddWindow(new ProcessingWindow());
+        ws.AddWindow(new QuestHelper());
+        cw = new();
+        ws.AddWindow(cw);
 
-            Svc.Framework.Update += OnFrameworkUpdate;
-            Svc.ClientState.Logout += DisableEndurance;
-            Svc.ClientState.Login += DisableEndurance;
-            Svc.Condition.ConditionChange += Condition_ConditionChange;
+        Svc.Framework.Update += OnFrameworkUpdate;
+        Svc.ClientState.Logout += DisableEndurance;
+        Svc.ClientState.Login += DisableEndurance;
+        Svc.Condition.ConditionChange += Condition_ConditionChange;
 
-            PluginUi.OpenWindow = OpenWindow.Main;
+        PluginUi.OpenWindow = OpenWindow.Main;
 
-            ConvertCraftingLists();
-        }
+        ConvertCraftingLists();
     }
 
     private void DisableEndurance(int type, int code)
@@ -163,7 +160,7 @@ public unsafe class Artisan : IDalamudPlugin
 
     private void Condition_ConditionChange(ConditionFlag flag, bool value)
     {
-        
+
         if (P.Config.RequestToStopDuty)
         {
             if (flag == ConditionFlag.WaitingForDutyFinder && value)
@@ -238,19 +235,16 @@ public unsafe class Artisan : IDalamudPlugin
 
         LuminaSheets.Dispose();
 
-        if (!DalamudInfo.IsOnStaging())
-        {
-            CraftingListContextMenu.Dispose();
-            UniversalsisClient.Dispose();
+        CraftingListContextMenu.Dispose();
+        UniversalsisClient.Dispose();
 
-            Svc.Condition.ConditionChange -= Condition_ConditionChange;
-            Svc.Framework.Update -= OnFrameworkUpdate;
-            Svc.ClientState.Logout -= DisableEndurance;
-            Svc.ClientState.Login -= DisableEndurance;
-            Endurance.Dispose();
-            RetainerInfo.Dispose();
-            IPC.IPC.Dispose();
-        }
+        Svc.Condition.ConditionChange -= Condition_ConditionChange;
+        Svc.Framework.Update -= OnFrameworkUpdate;
+        Svc.ClientState.Logout -= DisableEndurance;
+        Svc.ClientState.Login -= DisableEndurance;
+        Endurance.Dispose();
+        RetainerInfo.Dispose();
+        IPC.IPC.Dispose();
         ECommonsMain.Dispose();
         P = null!;
     }

--- a/Artisan/UI/PluginUI.cs
+++ b/Artisan/UI/PluginUI.cs
@@ -87,8 +87,10 @@ namespace Artisan.UI
         {
             if (DalamudInfo.IsOnStaging())
             {
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
                 ImGui.Text("Artisan is not designed to work on non-release versions of Dalamud. Please type /xlbranch, click 'release' and then 'Pick & Restart'.");
                 ImGui.Text("Any bugs created will not be supported until it is recreated on the release branch.");
+                ImGui.PopStyleColor();
             }
 
             var region = ImGui.GetContentRegionAvail();

--- a/Artisan/UI/PluginUI.cs
+++ b/Artisan/UI/PluginUI.cs
@@ -87,8 +87,8 @@ namespace Artisan.UI
         {
             if (DalamudInfo.IsOnStaging())
             {
-                ImGui.Text($"Artisan is not designed to work on non-release versions of Dalamud. Please type /xlbranch, click 'release' and then 'Pick & Restart'.");
-                return;
+                ImGui.Text("Artisan is not designed to work on non-release versions of Dalamud. Please type /xlbranch, click 'release' and then 'Pick & Restart'.");
+                ImGui.Text("Any bugs created will not be supported until it is recreated on the release branch.");
             }
 
             var region = ImGui.GetContentRegionAvail();


### PR DESCRIPTION
It is very annoying having to deal with checking if things work or not as one of the maintainers of ClientStructs when parts of the tools I use decides to be annoying and block itself when it is not on the "correct" branch.

This will have a clear red label at the top of the UI that this is not the supported method and any bugs related to it will not be handled.