### PR TITLE
12.0.0/net9.0 update

### DIFF
--- a/Artisan/Artisan.csproj
+++ b/Artisan/Artisan.csproj
@@ -20,7 +20,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<Platforms>x64</Platforms>
 		<Nullable>enable</Nullable>
 		<LangVersion>preview</LangVersion>
@@ -33,7 +33,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<Platforms>x64</Platforms>
 		<Nullable>enable</Nullable>
 		<LangVersion>preview</LangVersion>
@@ -87,7 +87,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.13" />
+    <PackageReference Include="DalamudPackager" Version="12.0.0" />
     <PackageReference Include="Discord.Net.Webhook" Version="3.15.3" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
@@ -128,6 +128,10 @@
     </Reference>
 	  <Reference Include="Dalamud.Common">
 		  <HintPath>$(DalamudLibPath)Dalamud.Common.dll</HintPath>
+		  <Private>False</Private>
+	  </Reference>
+	  <Reference Include="InteropGenerator.Runtime">
+		  <HintPath>$(DalamudLibPath)InteropGenerator.Runtime.dll</HintPath>
 		  <Private>False</Private>
 	  </Reference>
   </ItemGroup>

--- a/Artisan/GameInterop/Crafting.cs
+++ b/Artisan/GameInterop/Crafting.cs
@@ -490,7 +490,7 @@ public static unsafe class Crafting
         TrainedPerfectionAvailable = ActionManagerEx.CanUseSkill(Skills.TrainedPerfection),
         QuickInnoAvailable = ActionManagerEx.CanUseSkill(Skills.QuickInnovation),
         QuickInnoLeft = !craft.Specialist ? 0 : ActionManagerEx.CanUseSkill(Skills.QuickInnovation) ? 1 : predictedStep?.QuickInnoLeft ?? 0,
-        ExpedienceLeft = GetStatus(Buffs.Expedience)?.StackCount ?? 0,
+        ExpedienceLeft = GetStatus(Buffs.Expedience)?.Param ?? 0,
         PrevActionFailed = predictedStep?.PrevActionFailed ?? false,
         PrevComboAction = predictedStep?.PrevComboAction ?? Skills.None,
     };

--- a/Artisan/RawInformation/LuminaSheets.cs
+++ b/Artisan/RawInformation/LuminaSheets.cs
@@ -32,8 +32,6 @@ namespace Artisan.RawInformation
 
         public static Dictionary<uint, CraftAction>? CraftActions;
 
-        public static Dictionary<uint, CraftLevelDifference>? CraftLevelDifference;
-
         public static Dictionary<uint, RecipeLevelTable>? RecipeLevelTableSheet;
 
         public static Dictionary<uint, Addon>? AddonSheet;
@@ -94,9 +92,6 @@ namespace Artisan.RawInformation
                        .ToDictionary(i => i.RowId, i => i);
 
             CraftActions = Svc.Data?.GetExcelSheet<CraftAction>()?
-                       .ToDictionary(i => i.RowId, i => i);
-
-            CraftLevelDifference = Svc.Data?.GetExcelSheet<CraftLevelDifference>()?
                        .ToDictionary(i => i.RowId, i => i);
 
             RecipeLevelTableSheet = Svc.Data?.GetExcelSheet<RecipeLevelTable>()?

--- a/Artisan/RawInformation/MemoryHelper.cs
+++ b/Artisan/RawInformation/MemoryHelper.cs
@@ -270,7 +270,7 @@ namespace Artisan.RawInformation
 
             var len = Math.Max(utf8String->BufUsed, utf8String->StringLength);
 
-            return ReadSeString((IntPtr)ptr, (int)len);
+            return ReadSeString((IntPtr)ptr.Value, (int)len);
         }
 
         #endregion

--- a/Artisan/RawInformation/Spiritbond.cs
+++ b/Artisan/RawInformation/Spiritbond.cs
@@ -11,29 +11,29 @@ namespace Artisan.RawInformation
 {
     public unsafe static class Spiritbond
     {
-        public static ushort Weapon { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[0].Spiritbond; }
+        public static ushort Weapon { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[0].SpiritbondOrCollectability; }
 
-        public static ushort Offhand { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[1].Spiritbond; }
+        public static ushort Offhand { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[1].SpiritbondOrCollectability; }
 
-        public static ushort Helm { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[2].Spiritbond; }
+        public static ushort Helm { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[2].SpiritbondOrCollectability; }
 
-        public static ushort Body { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[3].Spiritbond; }
+        public static ushort Body { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[3].SpiritbondOrCollectability; }
 
-        public static ushort Hands { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[4].Spiritbond; }
+        public static ushort Hands { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[4].SpiritbondOrCollectability; }
 
-        public static ushort Legs { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[6].Spiritbond; }
+        public static ushort Legs { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[6].SpiritbondOrCollectability; }
 
-        public static ushort Feet { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[7].Spiritbond; }
+        public static ushort Feet { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[7].SpiritbondOrCollectability; }
 
-        public static ushort Earring { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[8].Spiritbond; }
+        public static ushort Earring { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[8].SpiritbondOrCollectability; }
 
-        public static ushort Neck { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[9].Spiritbond; }
+        public static ushort Neck { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[9].SpiritbondOrCollectability; }
 
-        public static ushort Wrist { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[10].Spiritbond; }
+        public static ushort Wrist { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[10].SpiritbondOrCollectability; }
 
-        public static ushort Ring1 { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[11].Spiritbond; }
+        public static ushort Ring1 { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[11].SpiritbondOrCollectability; }
 
-        public static ushort Ring2 { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[12].Spiritbond; }
+        public static ushort Ring2 { get => InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems)->Items[12].SpiritbondOrCollectability; }
 
         public static bool IsSpiritbondReadyAny()
         {

--- a/Artisan/Tasks/TaskSelectRetainer.cs
+++ b/Artisan/Tasks/TaskSelectRetainer.cs
@@ -380,7 +380,7 @@ internal unsafe static class RetainerHandlers
         var list = new List<string>();
         for (int i = 0; i < addon->PopupMenu.PopupMenu.EntryCount; i++)
         {
-            list.Add(MemoryHelper.ReadSeStringNullTerminated((nint)addon->PopupMenu.PopupMenu.EntryNames[i]).ExtractText());
+            list.Add(MemoryHelper.ReadSeStringNullTerminated((nint)addon->PopupMenu.PopupMenu.EntryNames[i].Value).ExtractText());
         }
         return list;
     }

--- a/DemoScripts/DemoScripts.csproj
+++ b/DemoScripts/DemoScripts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
updated for 12.0.0/net 9.0

```
08:10:00.843 | ERR | Exception during raise of "Void <InvokeSafely>b__0()"
	System.TypeInitializationException: The type initializer for 'Artisan.GameInterop.PreCrafting' threw an exception.
	 ---> System.Collections.Generic.KeyNotFoundException: Can't find a signature of 40 55 53 56 57 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 0F 48 8B 7D 7F
	   at Dalamud.Game.SigScanner.Scan(IntPtr baseAddress, Int32 size, String signature) in /_/Dalamud/Game/SigScanner.cs:line 124
	   at Dalamud.Game.SigScanner.ScanText(String signature) in /_/Dalamud/Game/SigScanner.cs:line 279
	   at Dalamud.Hooking.Internal.GameInteropProviderPluginScoped.HookFromSignature[T](String signature, T detour, HookBackend backend) in /_/Dalamud/Hooking/Internal/GameInteropProviderPluginScoped.cs:line 90
	   at Artisan.GameInterop.PreCrafting..cctor() in G:\Downloads\Artisan\Artisan\GameInterop\PreCrafting.cs:line 47
	   --- End of inner exception stack trace ---
	   at Artisan.GameInterop.PreCrafting.Update() in G:\Downloads\Artisan\Artisan\GameInterop\PreCrafting.cs:line 85
	   at Artisan.Artisan.OnFrameworkUpdate(IFramework framework) in G:\Downloads\Artisan\Artisan\Artisan.cs:line 201
	   at Dalamud.Utility.EventHandlerExtensions.HandleInvoke(Action act) in /_/Dalamud/Utility/EventHandlerExtensions.cs:line 124
```

GameInterop/Precrafting.cs throws an error when trying to scan the signature for _clickButton. The signature changed? dunno how to find it, never did rev engineering before.
CraftLevelDifference didn't seem to refer to anything anymore in Lumina and couldn't find any usage in Artisan, i removed it thus.
