### PR TITLE
Adding an option to replace the action instead of skipping

### DIFF
--- a/Artisan/CraftingLogic/Solvers/MacroSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/MacroSolver.cs
@@ -52,6 +52,27 @@ public class MacroSolver : Solver
             var s = _macro.Steps[_nextStep++];
             var action = s.Action;
 
+            if ((s.ExcludeNormal && step.Condition == Condition.Normal) ||
+                (s.ExcludeGood && step.Condition == Condition.Good) ||
+                (s.ExcludePoor && step.Condition == Condition.Poor) ||
+                (s.ExcludeExcellent && step.Condition == Condition.Excellent) ||
+                (s.ExcludeCentered && step.Condition == Condition.Centered) ||
+                (s.ExcludeSturdy && step.Condition == Condition.Sturdy) ||
+                (s.ExcludePliant && step.Condition == Condition.Pliant) ||
+                (s.ExcludeMalleable && step.Condition == Condition.Malleable) ||
+                (s.ExcludePrimed && step.Condition == Condition.Primed) ||
+                (s.ExcludeGoodOmen && step.Condition == Condition.GoodOmen))
+            {
+                if (s.ReplaceOnExclude)
+                {
+                    action = s.ReplacementAction;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+
             if (_macro.Options.SkipQualityIfMet && step.Quality >= craft.CraftQualityMin3 && ActionIsQuality(action))
             {
                 continue;
@@ -67,19 +88,6 @@ public class MacroSolver : Solver
                 continue;
             }
 
-            if ((s.ExcludeNormal && step.Condition == Condition.Normal) ||
-                (s.ExcludeGood && step.Condition == Condition.Good) ||
-                (s.ExcludePoor && step.Condition == Condition.Poor) ||
-                (s.ExcludeExcellent && step.Condition == Condition.Excellent) ||
-                (s.ExcludeCentered && step.Condition == Condition.Centered) ||
-                (s.ExcludeSturdy && step.Condition == Condition.Sturdy) ||
-                (s.ExcludePliant && step.Condition == Condition.Pliant) ||
-                (s.ExcludeMalleable && step.Condition == Condition.Malleable) ||
-                (s.ExcludePrimed && step.Condition == Condition.Primed) ||
-                (s.ExcludeGoodOmen && step.Condition == Condition.GoodOmen))
-            {
-                continue;
-            }
 
             if (action == Skills.TouchCombo)
             {

--- a/Artisan/CraftingLogic/Solvers/MacroSolverSettings.cs
+++ b/Artisan/CraftingLogic/Solvers/MacroSolverSettings.cs
@@ -39,6 +39,19 @@ public class MacroSolverSettings
         public bool ExcludeMalleable = false;
         public bool ExcludePrimed = false;
         public bool ExcludeGoodOmen = false;
+        public bool ReplaceOnExclude = false;
+        public Skills ReplacementAction = Skills.None;
+
+        public bool HasExcludeCondition =>  ExcludeNormal ||
+                                            ExcludeGood ||
+                                            ExcludePoor  ||
+                                            ExcludeExcellent ||
+                                            ExcludeCentered ||
+                                            ExcludeSturdy ||
+                                            ExcludePliant||
+                                            ExcludeMalleable ||
+                                            ExcludePrimed ||
+                                            ExcludeGoodOmen;
     }
 
     public List<Macro> Macros = new();

--- a/Artisan/UI/MacroEditor.cs
+++ b/Artisan/UI/MacroEditor.cs
@@ -377,6 +377,7 @@ namespace Artisan.UI
                         var steps = MacroUI.ParseMacro(_rawMacro);
                         if (steps.Count > 0 && !SelectedMacro.Steps.SequenceEqual(steps))
                         {
+                            selectedStepIndex=steps.Count-1;
                             SelectedMacro.Steps = steps;
                             P.Config.Save();
                             DuoLog.Information($"Macro Updated");
@@ -388,6 +389,7 @@ namespace Artisan.UI
                         var steps = MacroUI.ParseMacro(_rawMacro);
                         if (steps.Count > 0 && !SelectedMacro.Steps.SequenceEqual(steps))
                         {
+                            selectedStepIndex=steps.Count-1;
                             SelectedMacro.Steps = steps;
                             P.Config.Save();
                             DuoLog.Information($"Macro Updated");

--- a/Artisan/UI/MacroEditor.cs
+++ b/Artisan/UI/MacroEditor.cs
@@ -182,7 +182,7 @@ namespace Artisan.UI
                     for (int i = 0; i < SelectedMacro.Steps.Count; i++)
                     {
                         var step = SelectedMacro.Steps[i];
-                        var selectedAction = ImGui.Selectable($"{i + 1}. {(step.Action == Skills.None ? "Artisan Recommendation" : step.Action.NameOfAction())}###selectedAction{i}", i == selectedStepIndex);
+                        var selectedAction = ImGui.Selectable($"{i + 1}. {(step.Action == Skills.None ? "Artisan Recommendation" : step.Action.NameOfAction())}{(step.HasExcludeCondition? " | ":"")}{(step.HasExcludeCondition&&step.ReplaceOnExclude?step.ReplacementAction.NameOfAction() : step.HasExcludeCondition?"skip":"")}###selectedAction{i}", i == selectedStepIndex);
                         if (selectedAction)
                             selectedStepIndex = i;
                     }
@@ -219,7 +219,7 @@ namespace Artisan.UI
                         ImGui.Spacing();
                         ImGuiEx.CenterColumnText($"Skip on these conditions", true);
 
-                        ImGui.BeginChild("ConditionalExcludes", new Vector2(ImGui.GetContentRegionAvail().X, 100f), false, ImGuiWindowFlags.AlwaysAutoResize);
+                        ImGui.BeginChild("ConditionalExcludes", new Vector2(ImGui.GetContentRegionAvail().X, step.HasExcludeCondition?200f:100f), false, ImGuiWindowFlags.AlwaysAutoResize);
                         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 0));
                         ImGui.Columns(3, null, false);
                         if (ImGui.Checkbox($"Normal", ref step.ExcludeNormal))
@@ -251,7 +251,50 @@ namespace Artisan.UI
 
                         ImGui.Columns(1);
                         ImGui.PopStyleVar();
+
+                        if (step.HasExcludeCondition)
+                        {
+                            ImGuiEx.CenterColumnText($"Exclude options", true);
+                            if (ImGui.Checkbox($"Instead of skipping replace with:", ref step.ReplaceOnExclude))
+                                P.Config.Save();
+
+                            if (step.ReplaceOnExclude)
+                            {
+                                if (ImGui.BeginCombo("###Select Replacement", step.ReplacementAction.NameOfAction()))
+                                {
+                                    if (ImGui.Selectable($"Artisan Recommendation"))
+                                    {
+                                        step.ReplacementAction = Skills.None;
+                                        P.Config.Save();
+                                    }
+
+                                    ImGuiComponents.HelpMarker("Uses a recommendation from the appropriate default solver, i.e Standard Recipe Solver for regular recipes, Expert Recipe Solver for expert recipes.");
+
+                                    if (ImGui.Selectable($"Touch Combo"))
+                                    {
+                                        step.ReplacementAction = Skills.TouchCombo;
+                                        P.Config.Save();
+                                    }
+
+                                    ImGuiComponents.HelpMarker("This will use the appropriate step of the 3-step touch combo, depending on the last action actually used. Useful if upgrading quality actions or skipping on conditions.");
+
+                                    ImGui.Separator();
+
+                                    foreach (var opt in Enum.GetValues(typeof(Skills)).Cast<Skills>().OrderBy(SheetExtensions.NameOfAction))
+                                    {
+                                        if (ImGui.Selectable(opt.NameOfAction()))
+                                        {
+                                            step.ReplacementAction = opt;
+                                            P.Config.Save();
+                                        }
+                                    }
+
+                                    ImGui.EndCombo();
+                                }
+                            }
+                        }
                         ImGui.EndChild();
+
                         if (ImGui.Button("Delete Action (Hold Ctrl)") && ImGui.GetIO().KeyCtrl)
                         {
                             SelectedMacro.Steps.RemoveAt(selectedStepIndex);


### PR DESCRIPTION
This adds the option to replace an action in a macro. My use case is protecting macros from failing due to excellent procs on buff steps by delaying the buff in most cases an excellent proc will be worth more than the buff and the buff can be applied during the poor following.

![image](https://github.com/user-attachments/assets/f10645ca-d682-4337-84b1-3173e51ce52c)

![image](https://github.com/user-attachments/assets/e70e05b8-b2b6-4cc6-8c1a-e267d4ee1f2e)
