### PR TITLE
Extended lists command to accept name

### DIFF
--- a/Artisan/Artisan.cs
+++ b/Artisan/Artisan.cs
@@ -304,30 +304,40 @@ public unsafe class Artisan : IDalamudPlugin
                             return;
                         }
                     }
-                    else if (P.Config.NewCraftingLists.Any(x => x.Name.Equals(subcommands[1], StringComparison.CurrentCultureIgnoreCase)))
+                    else
                     {
-                        if (subcommands.Length >= 3 && subcommands[2].ToLower() == "start")
+                        // Check if the last argument is "start" and we want to start the list
+                        bool isStartCommand = subcommands.Length >= 3 && subcommands[^1].ToLower() == "start";
+                        
+                        string listNameToFind = string.Join(" ", subcommands.Skip(1).Take(isStartCommand ? subcommands.Length - 2 : subcommands.Length - 1));
+                        
+                        var matchingList = P.Config.NewCraftingLists.FirstOrDefault(x => 
+                            x.Name.Equals(listNameToFind, StringComparison.CurrentCultureIgnoreCase));
+                            
+                        if (matchingList != null)
                         {
-                            if (!Endurance.Enable)
+                            if (isStartCommand)
                             {
-                                CraftingListUI.selectedList = P.Config.NewCraftingLists.First(x => x.Name.Equals(subcommands[1], StringComparison.CurrentCultureIgnoreCase));
-                                CraftingListUI.StartList();
+                                if (!Endurance.Enable)
+                                {
+                                    CraftingListUI.selectedList = matchingList;
+                                    CraftingListUI.StartList();
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                CraftingListUI.selectedList = matchingList;
+                                ListEditor editor = new(CraftingListUI.selectedList.ID);
                                 return;
                             }
                         }
                         else
                         {
-                            CraftingListUI.selectedList = P.Config.NewCraftingLists.First(x => x.Name.Equals(subcommands[1], StringComparison.CurrentCultureIgnoreCase));
-                            ListEditor editor = new(CraftingListUI.selectedList.ID);
+                            DuoLog.Error("List does not exist by name.");
                             return;
                         }
                     }
-                    else
-                    {
-                        DuoLog.Error("List does not exist by name.");
-                        return;
-                    }
-
                 }
                 else
                 {


### PR DESCRIPTION
Please consider this extension of the /artisan lists functionality.

Expands /artisan lists command to accept name, which most humans will better remember than arbitrary ID. Maintains original functionality for backwards compatibility. Updated tooltip.

The limitation in place for this function however is that Artisan does not require unique names for lists. As such the name command will return the first (read: oldest) NewCraftingList by index. I considered expanding the list creation functionality to require unique names, but settled on the .First implementation as I fear a new restraint may be backwards dysfunctional.