### PR TITLE
[Enhance][CraftingList] Show recipe requirements below solver in Crafting Lists

### DIFF
--- a/Artisan/UI/ListEditor.cs
+++ b/Artisan/UI/ListEditor.cs
@@ -1288,6 +1288,13 @@ internal class ListEditor : Window, IDisposable
             P.Config.RecipeConfigs[selectedListItem] = config;
             P.Config.Save();
         }
+        
+        ImGuiEx.TextV("Requirements:");
+        ImGui.SameLine();
+        using var style = ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(0, ImGui.GetStyle().ItemSpacing.Y));
+        ImGui.SameLine(137.6f.Scale());
+        ImGui.TextWrapped($"Difficulty: {craft.CraftProgress} | Durability: {craft.CraftDurability} | Quality: {(craft.CraftCollectible ? craft.CraftQualityMin3 : craft.CraftQualityMax)}");
+        ImGuiComponents.HelpMarker($"Shows the crafting requirements: Progress needed to complete the craft, how much Durability the recipe has, and Quality target required to reach the highest Quality level (In case of a Collectible). Use this information to select an appropriate macro, if desired.");
 
         ImGui.Checkbox($"Assume Max Starting Quality (for simulator)", ref hqSim);
 


### PR DESCRIPTION
Add Crafting Recipe Requirements Information below the Solver in the Crafting Lists, to help the user select macros, if needed.

(I can't find a way to add a small space between the text and the information icon)

![image](https://github.com/user-attachments/assets/127533d4-8c76-4e70-8feb-1c6fcf1a4ffb)
![image](https://github.com/user-attachments/assets/f8d592e0-7922-483f-9367-92da7b72a71e)
