### PR TITLE
Raphael solver - Adding stat based caching. Raising priority

### DIFF
--- a/Artisan/Configuration.cs
+++ b/Artisan/Configuration.cs
@@ -151,6 +151,8 @@ namespace Artisan
         public string? DiscordWebhookUrl;
 
         public ConcurrentDictionary<string, string> RaphaelSolverCache = [];
+        public bool RaphaelAutoBuild = true;
+        public uint RaphaelMaxCacheSize = 1_000;
 
         public void Save()
         {

--- a/Artisan/CraftingLogic/CraftingProcessor.cs
+++ b/Artisan/CraftingLogic/CraftingProcessor.cs
@@ -40,7 +40,7 @@ public static class CraftingProcessor
         _solverDefs.Add(new ExpertSolverDefinition());
         _solverDefs.Add(new MacroSolverDefinition());
         _solverDefs.Add(new ScriptSolverDefinition());
-        _solverDefs.Add(new RaphaelSolverDefintion());
+        _solverDefs.Add(new RaphaelSolverDefinition());
 
         Crafting.CraftStarted += OnCraftStarted;
         Crafting.CraftAdvanced += OnCraftAdvanced;
@@ -54,11 +54,13 @@ public static class CraftingProcessor
         Crafting.CraftFinished -= OnCraftFinished;
     }
 
-    public static IEnumerable<ISolverDefinition.Desc> GetAvailableSolversForRecipe(CraftState craft, bool returnUnsupported, Type? skipSolver = null)
+    public static IEnumerable<ISolverDefinition.Desc> GetAvailableSolversForRecipe(CraftState craft, bool returnUnsupported, Type[]? skipSolvers = null)
     {
+        skipSolvers ??= [];
+
         foreach (var solver in _solverDefs)
         {
-            if (solver.GetType() == skipSolver)
+            if (skipSolvers.Contains(solver.GetType()))
                 continue;
 
             foreach (var f in solver.Flavours(craft))
@@ -68,6 +70,7 @@ public static class CraftingProcessor
                     yield return f;
                 }
             }
+
             yield return default;
         }
     }

--- a/Artisan/CraftingLogic/RecipeConfig.cs
+++ b/Artisan/CraftingLogic/RecipeConfig.cs
@@ -186,7 +186,7 @@ public class RecipeConfig
             ImGui.EndCombo();
         }
 
-        if (RaphaelCache.CLIExists())
+        if (RaphaelCache.CliExists.Value)
         {
             if (RaphaelCache.HasSolution(craft))
             {
@@ -213,7 +213,7 @@ public class RecipeConfig
             {
                 if (ImGui.Button("Cancel Raphael Generation", new Vector2(ImGui.GetContentRegionAvail().X, 25f.Scale())))
                 {
-                    RaphaelCache.Tasks.Clear();
+                    RaphaelCache.ActiveBuildTasks.Clear();
                 }
             }
 

--- a/Artisan/CraftingLogic/Simulator.cs
+++ b/Artisan/CraftingLogic/Simulator.cs
@@ -49,7 +49,10 @@ public static class Simulator
     }
 
     public static StepState CreateInitial(CraftState craft, int startingQuality)
-        => new()
+    {
+        craft.StartingQuality = startingQuality;
+
+        return new()
         {
             Index = 1,
             Durability = craft.CraftDurability,
@@ -61,6 +64,7 @@ public static class Simulator
             TrainedPerfectionAvailable = craft.StatLevel >= MinLevel(Skills.TrainedPerfection),
             Condition = Condition.Normal
         };
+    }
 
     public static CraftStatus Status(CraftState craft, StepState step)
     {

--- a/Artisan/CraftingLogic/Solvers/ExpertSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/ExpertSolver.cs
@@ -11,7 +11,7 @@ public class ExpertSolverDefinition : ISolverDefinition
     public IEnumerable<ISolverDefinition.Desc> Flavours(CraftState craft)
     {
         if (craft.CraftExpert)
-            yield return new(this, 0, 2, "Expert Recipe Solver", craft.StatLevel >= 90 ? "" : "Requires Level 90");
+            yield return new(this, 0, 3, "Expert Recipe Solver", craft.StatLevel >= 90 ? "" : "Requires Level 90");
     }
 
     public Solver Create(CraftState craft, int flavour) => new ExpertSolver();

--- a/Artisan/CraftingLogic/Solvers/MacroSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/MacroSolver.cs
@@ -1,5 +1,5 @@
 ﻿using Artisan.CraftingLists;
-using SharpDX.DirectWrite;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Condition = Artisan.CraftingLogic.CraftData.Condition;
@@ -31,10 +31,18 @@ public class MacroSolver : Solver
     private Solver? _fallback;
     private int _nextStep;
 
-    public MacroSolver(MacroSolverSettings.Macro m, CraftState craft)
+    public MacroSolver(MacroSolverSettings.Macro m, CraftState craft, Type? skipFallbackSolverType = null)
     {
         _macro = m;
-        _fallback = CraftingProcessor.GetAvailableSolversForRecipe(craft, false, typeof(MacroSolverDefinition)).MaxBy(f => f.Priority).CreateSolver(craft);
+        _fallback = CraftingProcessor.GetAvailableSolversForRecipe(
+                craft, 
+                false, 
+                skipFallbackSolverType is null 
+                    ? [typeof(MacroSolverDefinition)] 
+                    : [typeof(MacroSolverDefinition), skipFallbackSolverType]
+            )
+            .MaxBy(f => f.Priority)
+            .CreateSolver(craft);
     }
 
     public override Solver Clone()

--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -1,26 +1,29 @@
 ﻿using Artisan.UI;
 using ECommons.DalamudServices;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Artisan.CraftingLogic.Solvers
 {
-    public class RaphaelSolverDefintion : ISolverDefinition
+    public class RaphaelSolverDefinition : ISolverDefinition
     {
         public Solver Create(CraftState craft, int flavour)
         {
             var key = RaphaelCache.GetKey(craft);
-            var output = P.Config.RaphaelSolverCache.GetValueOrDefault(key);
+            var solveEntry = RaphaelCache.GetEntry(P.Config, key);
 
-            if (output == null) throw new System.Exception("Shouldn't be called");
+            if (solveEntry == null) throw new System.Exception("Shouldn't be called");
 
-            return new MacroSolver(new MacroSolverSettings.Macro()
+            return new RaphaelSolver(new MacroSolver(new MacroSolverSettings.Macro()
             {
                 Name = key,
-                Steps = MacroUI.ParseMacro(output.Replace("2", "II").Replace("MasterMend", "MastersMend"), true),
+                Steps = MacroUI.ParseMacro(solveEntry.Macro, true),
                 Options = new()
                 {
                     SkipQualityIfMet = true,
@@ -30,7 +33,7 @@ namespace Artisan.CraftingLogic.Solvers
                     MinControl = craft.StatControl,
                     MinCraftsmanship = craft.StatCraftsmanship,
                 }
-            }, craft);
+            }, craft, typeof(RaphaelSolverDefinition)));
         }
 
         public IEnumerable<ISolverDefinition.Desc> Flavours(CraftState craft)
@@ -38,65 +41,170 @@ namespace Artisan.CraftingLogic.Solvers
             var key = RaphaelCache.GetKey(craft);
             if (P.Config.RaphaelSolverCache.TryGetValue(key, out string? value))
             {
-                yield return new(this, -1, 2, "Raphael Recipe Solver");
+                yield return new(this, -1, 3, "Raphael Recipe Solver");
             }
+            else if (P.Config.RaphaelAutoBuild)
+            {
+                RaphaelCache.Build(craft);
+            }
+        }
+    }
+
+    internal sealed class RaphaelSolver : Solver
+    {
+        private readonly MacroSolver _macroSolver;
+
+        public RaphaelSolver(MacroSolver macroSolver)
+        {
+            _macroSolver = macroSolver;
+        }
+
+        public override Recommendation Solve(CraftState craft, StepState step)
+        {
+            return _macroSolver.Solve(craft, step);
+        }
+
+        public override Solver Clone()
+        {
+            return new RaphaelSolver((MacroSolver)_macroSolver.Clone());
         }
     }
 
     internal static class RaphaelCache
     {
-        internal static readonly ConcurrentDictionary<string, Task> Tasks = [];
+        public static readonly Lazy<bool> CliExists = new(CheckCLIExists);
+        private static readonly ConcurrentDictionary<string, SolveEntry> _parsedCache = [];
+
+        internal static readonly ConcurrentDictionary<string, Task> ActiveBuildTasks = [];
 
         public static void Build(CraftState craft)
         {
             var key = GetKey(craft);
 
-            if (CLIExists() && !Tasks.ContainsKey(key))
+            if (!CliExists.Value | ActiveBuildTasks.ContainsKey(key))
+                return;
+
+            P.Config.RaphaelSolverCache.TryRemove(key, out _);
+
+            Svc.Log.Information("Spawning Raphael process");
+
+            var startingQualityPercent = Convert.ToDouble(craft.StartingQuality) / Convert.ToDouble(craft.CraftQualityMax) * 100;
+            var manipulation = craft.UnlockedManipulation ? "--manipulation" : "";
+            var itemText = craft.IsCosmic ? $"--recipe-id {craft.RecipeId}" : $"--item-id {craft.ItemId}";
+            var process = new Process()
             {
-                P.Config.RaphaelSolverCache.TryRemove(key, out _);
-
-                Svc.Log.Information("Spawning Raphael process");
-
-                var manipulation = craft.UnlockedManipulation ? "--manipulation" : "";
-                var itemText = craft.IsCosmic ? $"--recipe-id {craft.RecipeId}" : $"--item-id {craft.ItemId}";
-                var process = new Process()
+                StartInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = Path.Join(Path.GetDirectoryName(Svc.PluginInterface.AssemblyLocation.FullName), "raphael-cli.exe"),
-                        Arguments = $"solve {itemText} {manipulation} --level {craft.StatLevel} --stats {craft.StatCraftsmanship} {craft.StatControl} {craft.StatCP} --output-variables actions", // Command to execute
-                        RedirectStandardOutput = true,
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    }
-                };
+                    FileName = Path.Join(Path.GetDirectoryName(Svc.PluginInterface.AssemblyLocation.FullName), "raphael-cli.exe"),
+                    Arguments = $"solve {itemText} {manipulation} --level {craft.StatLevel} --stats {craft.StatCraftsmanship} {craft.StatControl} {craft.StatCP} --initial-quality {startingQualityPercent} --output-variables actions", // Command to execute
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
 
-                Svc.Log.Information(process.StartInfo.Arguments);
+            Svc.Log.Information(process.StartInfo.Arguments);
 
-                var task = Task.Run(() =>
+            var task = new Task(() =>
+            {
+                process.Start();
+                var output = process.StandardOutput.ReadToEnd();
+
+                P.Config.RaphaelSolverCache[key] = 
+                    JsonConvert.SerializeObject(
+                        new SolveEntry() 
+                        { 
+                            LastUsed = DateTimeOffset.UtcNow, 
+                            Macro = output
+                                .Replace("\"", "")
+                                .Replace("[", "")
+                                .Replace("]", "")
+                                .Replace(",", "\n")
+                                .Replace("2", "II")
+                                .Replace("MasterMend", "MastersMend") 
+                        }
+                    );
+
+                while (P.Config.RaphaelSolverCache.Count > P.Config.RaphaelMaxCacheSize)
                 {
-                    process.Start();
-                    var output = process.StandardOutput.ReadToEnd();
-                    P.Config.RaphaelSolverCache[key] = output.Replace("\"", "").Replace("[", "").Replace("]", "").Replace(",", "\r\n");
-                    P.Config.Save();
-                    Tasks.Remove(key, out var _);
-                });
+                    var oldestKey = P.Config.RaphaelSolverCache.Keys
+                        .MinBy(k => GetEntry(P.Config, key)?.LastUsed ?? DateTimeOffset.UtcNow);
 
-                Tasks.TryAdd(key, task);
-            }
+                    if (oldestKey is null)
+                        break;
+
+                    P.Config.RaphaelSolverCache.Remove(oldestKey, out _);
+                    _parsedCache.Remove(oldestKey, out _);
+                }
+
+                P.Config.Save();
+                
+                ActiveBuildTasks.Remove(key, out _);
+            });
+
+            if (!ActiveBuildTasks.TryAdd(key, task))
+                return;
+
+            task.Start();
         }
 
         public static string GetKey(CraftState craft)
         {
-            return $"{craft.RecipeId}";
+            return $"{craft.RecipeId}-{craft.StatCraftsmanship}-{craft.StatControl}-{craft.StatCP}-{craft.StartingQuality}";
+        }
+
+        public static SolveEntry? GetEntry(Configuration config, string key)
+        {
+            if (!_parsedCache.TryGetValue(key, out var entry))
+            {
+                var value = config.RaphaelSolverCache.GetValueOrDefault(key);
+                if (value is null)
+                    return null;
+
+                try
+                {
+                    entry = JsonConvert.DeserializeObject<SolveEntry>(value);
+                }
+                catch
+                {
+                    // Old style entry, just remake
+                }
+
+                if (entry is null)
+                {
+                    config.RaphaelSolverCache.Remove(key, out _);
+                    config.Save();
+
+                    return null;
+                }
+
+                _parsedCache[key] = entry;
+            }
+
+            // Only compare dates to prevent churn
+            if (entry.LastUsed.Date != DateTime.UtcNow.Date)
+            {
+                entry.LastUsed = DateTime.UtcNow;
+                config.RaphaelSolverCache[key] = JsonConvert.SerializeObject(entry);
+                config.Save();
+            }
+
+            return entry;
         }
 
         public static bool HasSolution(CraftState craft) => P.Config.RaphaelSolverCache.TryGetValue(GetKey(craft), out var _);
-        public static bool InProgress(CraftState craft) => Tasks.TryGetValue(GetKey(craft), out var _);
+        public static bool InProgress(CraftState craft) => ActiveBuildTasks.TryGetValue(GetKey(craft), out var _);
 
-        internal static bool CLIExists()
+        internal static bool CheckCLIExists()
         {
             return File.Exists(Path.Join(Path.GetDirectoryName(Svc.PluginInterface.AssemblyLocation.FullName), "raphael-cli.exe"));
+        }
+
+        public record SolveEntry
+        {
+            public required string Macro { get; init; }
+            
+            public required DateTimeOffset LastUsed { get; set; }
         }
     }
 }

--- a/Artisan/CraftingLogic/State.cs
+++ b/Artisan/CraftingLogic/State.cs
@@ -38,6 +38,8 @@ public record class CraftState
     public byte CollectableMetadataKey;
     public bool IsCosmic;
 
+    public int StartingQuality;
+
     public uint ItemId;
     public uint RecipeId;
 


### PR DESCRIPTION
Ahoy! Wanted to add a few things in for the Raphael solver, putting the PR up if anyone is interested in it.
Happy if this is just inspiration rather than just merged in, or I can tweak it/have it tweaked however - I don't mind at all!

Changes:
* cache key now reads: `$"{craft.RecipeId}-{craft.StatCraftsmanship}-{craft.StatControl}-{craft.StatCP}-{craft.StartingQuality}"`. This should make a lot of stuff better. Added starting quality for this, but not sure on the implementation of that, honestly.
* Added auto build option (with no UI to change.. yet!). Because the cache key is so specific, there's no reason not to? makes for much nicer UX.
* Added `LastUsed` property to cached entries, so that they can be cleaned out when we get too many. Added config for max allowed too.
* Some other minor tweaks and fixings to get things going