### PR TITLE
Macro viewer breaks if 2 things have same ID so randomize ID

### DIFF
--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -99,9 +100,14 @@ namespace Artisan.CraftingLogic.Solvers
                 {
                     process.Start();
                     var output = process.StandardOutput.ReadToEnd();
+
+                    var rng = new Random();
+                    var ID = rng.Next(50001, Int32.MaxValue);
+                    while (P.Config.RaphaelSolverCacheV2.Any(kv => kv.Value.ID == ID))
+                        ID = rng.Next(50001, Int32.MaxValue);
                     P.Config.RaphaelSolverCacheV2[key] = new MacroSolverSettings.Macro()
                     {
-                        ID = (int)craft.RecipeId,
+                        ID = ID,
                         Name = key,
                         Steps = MacroUI.ParseMacro(output.Replace("\"", "").Replace("[", "").Replace("]", "").Replace(",", "\r\n").Replace("2", "II").Replace("MasterMend", "MastersMend"), true),
                         Options = new()


### PR DESCRIPTION
Since multiple macros may get generated for the same item based on food state using the item ID as the macro ID makes additional macros in the cache unelectable.

Changed it to just randomized like the regular macros.