### PR TITLE
Teleport to marketboard rather than just world

### DIFF
--- a/Artisan/UI/Tables/IngredientTable.cs
+++ b/Artisan/UI/Tables/IngredientTable.cs
@@ -403,7 +403,7 @@ namespace Artisan.UI.Tables
 
                         if (ImGui.IsItemClicked())
                         {
-                            Chat.Instance.SendMessage($"/li {server}");
+                            Chat.Instance.SendMessage($"/li {server} mb");
                         }
                     }
                 }


### PR DESCRIPTION
clicking on the marketboard price in the ingredient list now brings you to the marketboard in that world rather than just the world