### PR TITLE
Macro Assigner: Sliders now only switch between supported values

### DIFF
--- a/Artisan/RawInformation/HelperExtensions.cs
+++ b/Artisan/RawInformation/HelperExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Lumina.Excel.Sheets;
+﻿using System;
+using Lumina.Excel.Sheets;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,44 +9,31 @@ namespace Artisan.RawInformation
 {
     internal static class HelperExtensions
     {
-        public static void SortAndRemoveDuplicates(this List<int> list)
+        public static int FindClosestIndex(this List<int> list, int valueToFind)
         {
-            if (list.Count == 0)
-                return;
-            list.Sort();
-            int dest = 1;
-            int prev = list[0];
-            for (int src = 1; src < list.Count; ++src)
-                if (list[src] != prev)
-                    list[dest++] = list[src];
-            list.RemoveRange(dest, list.Count - dest);
-        }
+            int closestIndex = 0;
+            int smallestDifference = int.MaxValue;
 
-        public static int UpperBound(this List<int> list, int test)
-        {
-            int first = 0, size = list.Count;
-            while (size > 0)
+            for (int i = 0; i < list.Count; i++)
             {
-                int step = size / 2;
-                int mid = first + step;
-                if (list[mid] <= test)
+                int currentDifference = Math.Abs(list[i] - valueToFind);
+                if (currentDifference < smallestDifference)
                 {
-                    first = mid + 1;
-                    size -= step + 1;
-                }
-                else
-                {
-                    size = step;
+                    smallestDifference = list[i];
+                    closestIndex = i;
                 }
             }
-            return first;
+
+            return closestIndex;
         }
 
-        public static int FindClosest(this List<int> list, int test)
+        public static int GetByIndexOrDefault(this List<int> list, int index, int defaultValue = 0)
         {
-            var ub = list.UpperBound(test);
-            return ub == 0 ? list[0] : ub == list.Count ? list[list.Count - 1] : test - list[ub - 1] < list[ub] - test ? list[ub - 1] : list[ub];
+            if (index < 0 || index >= list.Count)
+                return defaultValue;
+            return list[index];
         }
+
         public static string GetNumbers(this string input)
         {
             if (input == null) return "";


### PR DESCRIPTION
Improves the difficulty/quality selection in the macro assigner: both sliders now only switch between actual difficulty/quality values, not all numbers between min and max. This makes it a lot easier to select specific items when they're very close to another value: all steps are equal in the UI -- there is no difference if you go from 9500 → 9504 or 19800 → 23400.

For example, the following two values are now actually easy to select, as there is one 'step' between them

![x](https://github.com/user-attachments/assets/35fff951-35b0-42d1-851c-c3f4b60d695b)
![x](https://github.com/user-attachments/assets/46c74c70-5e64-4fdc-86dd-2c916327469a)

There are only two possible difficulty values for level 96 crafts (2700 for materials like rroneek serge, 5400 for gear), so the slider shows only two values instead of all values between 2700 and 5400:

![x](https://github.com/user-attachments/assets/daa9d2ad-fee4-499a-b7d5-6c26f3157692)

Only effective downside is that ctrl+click on the UI elements no longer works (as the internal values are the index, not the actual difficulty/quality anymore), so that has been disabled.