### PR TITLE
Only include completable recipes if any 'already crafted recipe' option is checked

### DIFF
--- a/Artisan/CraftingList/SpecialLists.cs
+++ b/Artisan/CraftingList/SpecialLists.cs
@@ -30,7 +30,7 @@ namespace Artisan.CraftingLists
         private static Dictionary<int, bool> questRecipe = new Dictionary<int, bool>() { [1] = false, [2] = false };
         private static Dictionary<int, bool> isSecondary = new Dictionary<int, bool>() { [1] = false, [2] = false };
         private static Dictionary<int, bool> alreadyCrafted = new Dictionary<int, bool>() { [1] = false, [2] = false };
-        private static Dictionary<int, bool> countsToLog = new Dictionary<int, bool>() { [1] = false, [2] = false };
+        private static Dictionary<int, bool> isLevelBased = new Dictionary<int, bool>() { [1] = false, [2] = false };
         private static Dictionary<int, bool> isCollectable = new Dictionary<int, bool>() { [1] = false, [2] = false };
         private static Dictionary<int, bool> isHQAble = new Dictionary<int, bool>() { [1] = false, [2] = false };
 
@@ -130,19 +130,19 @@ namespace Artisan.CraftingLists
             }
 
             ImGui.TextWrapped($"Level-based Recipes");
-            if (ImGui.BeginListBox("###CountsLog", new System.Numerics.Vector2(ImGui.GetContentRegionAvail().X, 32f.Scale())))
+            if (ImGui.BeginListBox("###IsLevelBasedRecipe", new System.Numerics.Vector2(ImGui.GetContentRegionAvail().X, 32f.Scale())))
             {
                 ImGui.Columns(2, null, false);
-                bool yes = countsToLog[1];
+                bool yes = isLevelBased[1];
                 if (ImGui.Checkbox("Yes", ref yes))
                 {
-                    countsToLog[1] = yes;
+                    isLevelBased[1] = yes;
                 }
                 ImGui.NextColumn();
-                bool no = countsToLog[2];
+                bool no = isLevelBased[2];
                 if (ImGui.Checkbox("No", ref no))
                 {
-                    countsToLog[2] = no;
+                    isLevelBased[2] = no;
                 }
                 
                 ImGui.EndListBox();
@@ -455,19 +455,19 @@ namespace Artisan.CraftingLists
                     {
                         if (v.Key == 1)
                         {
-                            recipes.RemoveAll(x => P.ri.HasRecipeCrafted(x.RowId));
+                            recipes.RemoveAll(x => x.RowId >= 30000 || P.ri.HasRecipeCrafted(x.RowId));
                         }
                         else
                         {
-                            recipes.RemoveAll(x => !P.ri.HasRecipeCrafted(x.RowId));
+                            recipes.RemoveAll(x => x.RowId >= 30000 || !P.ri.HasRecipeCrafted(x.RowId));
                         }
                     }
                 }
             }
 
-            if (countsToLog.Any(x => x.Value))
+            if (isLevelBased.Any(x => x.Value))
             {
-                foreach (var v in countsToLog)
+                foreach (var v in isLevelBased)
                 {
                     if (!v.Value)
                     {
@@ -477,7 +477,7 @@ namespace Artisan.CraftingLists
                         }
                         else
                         {
-                            recipes.RemoveAll(x => x.RecipeNotebookList.RowId > 1000);
+                            recipes.RemoveAll(x => x.RecipeNotebookList.RowId >= 1000);
                         }
                     }
                 }


### PR DESCRIPTION
So on a purely functional level, `IsRecipeComplete` checks the recipe complete bitmask if (at the patch of writing) the recipe id is < 6408. The game currently has recipe rows until 6407, and then the next sequence of recipes starts at 30000.

Tangent: I guess it would be possible to make a more in-depth category filter:

- NotebookDivisionCategory has the information which categories include which crafters
- NotebookDivision 0 .. 40 are normal leveling recipes
- NotebookDivision 1000+ are in the other recipe tab with multiple categories (PR also fixes a bug related to this where the filter for 'level-based recipes' would exclude `carpenter master recipes (1)` if any option is selected)
- each crafting class is allocated a block of 40 rows, starting from 0 in RecipeNotebookList; the category can be looked up by `RecipeNotebookList.RowId % 40`
- RecipeNotebookList entries starting at 1000 can trivially be looked up against NotebookDivision, by using `(RecipeNotebookList.RowId - 1000) / 8 + 1000`, e.g. Paldao Lumber → 1408 in RecipeNotebookList → `(1408 - 1000) / 8 + 1000) = 1501` → `Master Recipes (10)`

so you could, in theory, add a category selection that includes either the NotebookDivisionCategory entries, or the NotebookDivision entries (or both). This could maybe replace 'Secondary Recipe' (i don't know what that even is), 'Collectable Recipe', 'Level-based Recipe' and 'Recipe from a Book'.

However, that's just something what I saw while working on this - I want actually complete-able recipes in my crafting list, so that I can... well, complete them; and any of the master recipes/collectable recipes etc. aren't really helpful for `already crafted recipe: no` - you can never complete them.

I also renamed countsToLog to isLevelBased (the UI label is 'level-based recipes'), as furniture also counts towards the crafting log.