### PR TITLE
raphCacheV6

### DIFF
--- a/Artisan/Configuration.cs
+++ b/Artisan/Configuration.cs
@@ -171,6 +171,9 @@ namespace Artisan
         public RaphaelSolverSettings RaphaelSolverConfig = new();
         public ConcurrentDictionary<string, MacroSolverSettings.Macro> RaphaelSolverCacheV4 = [];
         public ConcurrentDictionary<string, MacroSolverSettings.Macro> RaphaelSolverCacheV5 = [];
+        [NonSerialized] // stored in a separate dedicated file
+        public ConcurrentDictionary<RaphaelOptions, MacroSolverSettings.Macro> RaphaelSolverCacheV6 = [];
+        public bool RaphaelV5Converted = false;
         public bool ShowLevelingRecipeProgress = true;
         public bool ShowOtherRecipeProgress = true;
         public bool ExitCraftStanceEndurance = true;
@@ -179,8 +182,25 @@ namespace Artisan
         public TrackConditions DebugTrackConditions = new TrackConditions();
         public bool DebugTrackConditionData = false;
 
+        [NonSerialized]
+        public readonly DirectoryInfo ConfigDirectory;
+
+        public Configuration()
+        {
+            ConfigDirectory = Svc.PluginInterface.ConfigDirectory;
+            try
+            {
+                Directory.CreateDirectory(ConfigDirectory.FullName);
+            }
+            catch (Exception e)
+            {
+                Svc.Log.Error($"Could not create config directory \"{ConfigDirectory.FullName}\":\n{e}");
+            }
+        }
+
         public void Save()
         {
+            RaphaelCache.WriteRaphaelCache(this);
             Svc.PluginInterface.SavePluginConfig(this);
         }
 
@@ -193,7 +213,11 @@ namespace Artisan
                 var json = JObject.Parse(contents);
                 var version = (int?)json["Version"] ?? 0;
                 ConvertConfig(json, version);
-                return json.ToObject<Configuration>() ?? new();
+                var loadedConfig = json.ToObject<Configuration>() ?? new();
+
+                RaphaelCache.LoadRaphaelCache(loadedConfig, false);
+
+                return loadedConfig;
             }
             catch (Exception e)
             {

--- a/Artisan/CraftingLogic/RecipeConfig.cs
+++ b/Artisan/CraftingLogic/RecipeConfig.cs
@@ -140,6 +140,7 @@ public class RecipeConfig
             changed |= DrawExpertProfiles(craft);
         DrawWarnings(craft);
         RaphaelCache.DrawRaphaelDropdown(craft, liveStats);
+        ImGui.Separator();
         DrawSimulator(craft);
         return changed;
     }
@@ -446,10 +447,10 @@ public class RecipeConfig
                     if (solver.Name == "Raphael Recipe Solver" && !RaphaelCache.HasSolution(craft, out _))
                         ImGuiEx.TextCentered($"Unable to generate a simulator without a Raphael solution generated.");
                     else
-                        ImGuiEx.TextCentered(hintColor, solverHint);
+                        ImGuiEx.TextCentered(hintColor, $"[{solver.Name.Split(' ')[0].Trim(":")}] {solverHint}");
             }
             else
-                ImGuiEx.TextCentered($"Please run this recipe in the simulator for results.");
+                ImGuiEx.TextCentered($"[Expert] Please run this recipe in the simulator for results.");
 
             if (ImGui.IsItemClicked())
             {

--- a/Artisan/CraftingLogic/Solvers/MacroSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/MacroSolver.cs
@@ -137,8 +137,10 @@ public class MacroSolver : Solver, ICraftValidator
         return new(Skills.None, "Macro has completed. Please continue to manually craft.");
     }
 
-    private static bool ActionIsQuality(Skills skill) => skill is Skills.BasicTouch or Skills.StandardTouch or Skills.AdvancedTouch or Skills.HastyTouch or Skills.PreparatoryTouch
+    public static bool ActionIsQuality(Skills skill) => skill is Skills.BasicTouch or Skills.StandardTouch or Skills.AdvancedTouch or Skills.HastyTouch or Skills.PreparatoryTouch
         or Skills.PreciseTouch or Skills.PrudentTouch or Skills.TrainedFinesse or Skills.ByregotsBlessing or Skills.GreatStrides or Skills.Innovation or Skills.TouchCombo or Skills.TouchComboRefined;
+
+    public static bool ActionIsProgress(Skills skill) => skill is Skills.BasicSynthesis or Skills.CarefulSynthesis or Skills.RapidSynthesis or Skills.Groundwork or Skills.IntensiveSynthesis or Skills.PrudentSynthesis or Skills.MuscleMemory or Skills.DelicateSynthesis;
 
     private static bool ActionIsUpgradeableQuality(Skills skill) => skill is Skills.HastyTouch or Skills.PreparatoryTouch or Skills.AdvancedTouch or Skills.StandardTouch or Skills.BasicTouch;
     private static bool ActionIsUpgradeableProgress(Skills skill) => skill is Skills.Groundwork or Skills.PrudentSynthesis or Skills.CarefulSynthesis or Skills.BasicSynthesis;

--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -295,6 +295,9 @@ namespace Artisan.CraftingLogic.Solvers
 
             return new RaphaelOptions()
             { 
+                MinCraftsmanship = craft.StatCraftsmanship,
+                MinControl = craft.StatControl,
+                MinCP = craft.StatCP,
                 Level = craft.CraftLevel,
                 Progress = craft.CraftProgress,
                 QualityMax = craft.CraftQualityMax,

--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -414,6 +414,10 @@ namespace Artisan.CraftingLogic.Solvers
                 {
                     ImGuiEx.Text(ImGuiColors.DalamudGrey, "Raphael Solver Settings");
                 }
+                else
+                {
+                    ImGui.Dummy(new Vector2(0, 2f));
+                }
 
                 if (showReliability)
                 {

--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -10,15 +10,19 @@ using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.ImGuiMethods;
 using ECommons.Logging;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using static Artisan.CraftingLogic.Solvers.MacroSolverSettings;
 
 namespace Artisan.CraftingLogic.Solvers
 {
@@ -29,7 +33,6 @@ namespace Artisan.CraftingLogic.Solvers
             if (craft.StatLevel < 7)
                 return new StandardSolver();
 
-            var key = RaphaelCache.GetKey(craft);
             if (RaphaelCache.HasSolution(craft, out var output))
             {
                 return new MacroSolver(output!, craft);
@@ -50,36 +53,33 @@ namespace Artisan.CraftingLogic.Solvers
 
     internal static class RaphaelCache
     {
-        internal static readonly ConcurrentDictionary<string, RaphaelTaskInfo> Tasks = [];
+        internal static readonly ConcurrentDictionary<RaphaelOptions, RaphaelTaskInfo> Tasks = [];
         [NonSerialized]
-        public static Dictionary<string, RaphaelSolutionConfig> TempConfigs = new();
+        public static List<RaphaelSolutionConfig> TempConfigs = [];
 
-        internal sealed class RaphaelTaskInfo
+        [NonSerialized]
+        public const string RaphaelFileName = "RaphaelCache.dat";
+
+        internal sealed class RaphaelTaskInfo(CancellationTokenSource cts, Task task, bool fromStartCraft)
         {
-            public CancellationTokenSource Cancellation { get; set; }
-            public Task Task { get; set; }
-            public volatile bool FromStartCraft;
+            public CancellationTokenSource Cancellation { get; set; } = cts;
+            public Task Task { get; set; } = task;
+            public volatile bool FromStartCraft = fromStartCraft;
             public volatile bool Succeeded;
-
-            public RaphaelTaskInfo(CancellationTokenSource cts, Task task, bool fromStartCraft)
-            {
-                Cancellation = cts;
-                Task = task;
-                FromStartCraft = fromStartCraft;
-            }
         }
-
 
         public static void Build(CraftState craft, RaphaelSolutionConfig config, bool fromStartCraft = false)
         {
-            if (craft.StatLevel < 7) return;
+            if (craft.StatLevel < 7) return; // can't run raphael without Master's Mend
 
-            var key = GetKey(craft);
+            // don't build if a task is already running with these options
+            var key = GetOptions(craft, config);
             if (!CLIExists() || Tasks.ContainsKey(key)) return;
 
-            P.Config.RaphaelSolverCacheV5.TryRemove(key, out _);
+            // nuke the old macro if one exists
+            P.Config.RaphaelSolverCacheV6.TryRemove(key, out _);
 
-            var manipulation = craft.UnlockedManipulation ? "--manipulation" : "";
+            var manipulation = config.HasManipulation ? "--manipulation" : "";
             var itemText = $"--custom-recipe {craft.LevelTable.RowId} {craft.CraftProgress} {(craft.CraftCollectible && !craft.IsCosmic ? craft.CraftQualityMin3 : craft.CraftQualityMax)} {craft.CraftDurability} {(craft.CraftExpert ? "1" : "0")} --stellar-steady-hand {Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}";
 
             var argsList = new List<string>
@@ -89,8 +89,8 @@ namespace Artisan.CraftingLogic.Solvers
 
             if (config.EnsureReliability) argsList.Add("--adversarial");
             if (config.BackloadProgress) argsList.Add("--backload-progress");
-            if (config.HeartAndSoul) argsList.Add("--heart-and-soul");
-            if (config.QuickInno) argsList.Add("--quick-innovation");
+            if (config.UseHeartAndSoul) argsList.Add("--heart-and-soul");
+            if (config.UseQuickInno) argsList.Add("--quick-innovation");
             if (P.Config.RaphaelSolverConfig.MaximumThreads > 0)
                 argsList.Add($"--threads {P.Config.RaphaelSolverConfig.MaximumThreads}");
 
@@ -163,12 +163,12 @@ namespace Artisan.CraftingLogic.Solvers
                                                    .Split(", ")
                                                    .Select(x => int.TryParse(x, out int n) ? n : 0);
 
-                        P.Config.RaphaelSolverCacheV5[key] = new MacroSolverSettings.Macro
+                        P.Config.RaphaelSolverCacheV6[key] = new MacroSolverSettings.Macro
                         {
-                            ID = new Random().Next(50001, 10000000),
-                            Name = key,
+                            ID = GetNewID(),
+                            Name = GetTextKey(craft, config),
                             Steps = MacroUI.ParseMacro(cleansedOutput),
-                            Options = new()
+                            Options = new RaphaelOptions()
                             {
                                 SkipQualityIfMet = false,
                                 UpgradeProgressActions = false,
@@ -176,10 +176,21 @@ namespace Artisan.CraftingLogic.Solvers
                                 MinCP = craft.StatCP,
                                 MinControl = craft.StatControl,
                                 MinCraftsmanship = craft.StatCraftsmanship,
+                                Level = craft.CraftLevel,
+                                Progress = craft.CraftProgress,
+                                QualityMax = craft.CraftQualityMax,
+                                Durability = craft.CraftDurability,
+                                IsExpert = craft.CraftExpert,
+                                InitialQuality = craft.InitialQuality,
+                                IsSpecialist = craft.Specialist,
+                                SteadyHandUses = Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand),
+                                SolutionConfig = config
                             }
                         };
 
-                        info.Succeeded = P.Config.RaphaelSolverCacheV5[key]?.Steps.Count > 0;
+                        Svc.Log.Debug($"Saved new macro to Raphael cache, ID: {P.Config.RaphaelSolverCacheV6[key].ID}");
+
+                        info.Succeeded = P.Config.RaphaelSolverCacheV6[key]?.Steps.Count > 0;
                     }
                 }
                 catch (OperationCanceledException)
@@ -205,7 +216,7 @@ namespace Artisan.CraftingLogic.Solvers
             Tasks.TryAdd(key, info);
         }
 
-        private static void AutoSwitch(CraftState craft, string key)
+        private static void AutoSwitch(CraftState craft, RaphaelOptions key)
         {
             static bool autoSwitchOk(uint recipeId)
             {
@@ -264,7 +275,7 @@ namespace Artisan.CraftingLogic.Solvers
                             }
                             if (autoSwitchOk(c.Recipe.RowId))
                             {
-                                Svc.Log.Information($"Switching {c.Recipe.RowId} ({c.Recipe.ItemResult.Value.Name}) to Raphael solver");
+                                //Svc.Log.Information($"Switching {c.Recipe.RowId} ({c.Recipe.ItemResult.Value.Name}) to Raphael solver");
                                 var switchConfig = P.Config.RecipeConfigs.GetValueOrDefault(c.Recipe.RowId) ?? new();
                                 switchConfig.SolverType = opt.Def.GetType().FullName!;
                                 switchConfig.SolverFlavour = opt.Flavour;
@@ -278,43 +289,216 @@ namespace Artisan.CraftingLogic.Solvers
             }
         }
 
-        public static string GetKey(CraftState craft)
+        public static RaphaelOptions GetOptions(CraftState craft, RaphaelSolutionConfig? config)
         {
-            return $"{craft.CraftLevel}/{craft.CraftProgress}/{craft.CraftQualityMax}/{craft.CraftDurability}-{craft.StatCraftsmanship}/{craft.StatControl}/{craft.StatCP}-{(craft.CraftExpert ? "Ex" : "St")}/{craft.InitialQuality}/{(craft.Specialist ? "Sp" : "Re")}/Steady{Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}";
+            config ??= GetRaphConfig(craft);
+
+            return new RaphaelOptions()
+            { 
+                Level = craft.CraftLevel,
+                Progress = craft.CraftProgress,
+                QualityMax = craft.CraftQualityMax,
+                Durability = craft.CraftDurability,
+                IsExpert = craft.CraftExpert,
+                InitialQuality = craft.InitialQuality,
+                IsSpecialist = craft.Specialist,
+                SteadyHandUses = Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand),
+                SolutionConfig = config
+            };
         }
 
-        public static RaphaelSolutionConfig GetConfigFromTempOrDefault(CraftState craft)
+        // this key is for identifying solutions while debugging; code should look up solutions by their RaphaelOptions
+        public static string GetTextKey(CraftState craft, RaphaelSolutionConfig config)
         {
-            var key = GetKey(craft);
-            var config = new RaphaelSolutionConfig();
-
-            var hasTempConfig = TempConfigs.TryGetValue(key, out var tempconfig);
-            var hasDelins = Crafting.DelineationCount() > 0;
-            config.EnsureReliability = hasTempConfig ? tempconfig.EnsureReliability : P.Config.RaphaelSolverConfig.AllowEnsureReliability;
-            config.BackloadProgress = hasTempConfig ? tempconfig.BackloadProgress : P.Config.RaphaelSolverConfig.AllowBackloadProgress;
-            config.HeartAndSoul = hasTempConfig ? tempconfig.HeartAndSoul : P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist && hasDelins;
-            config.QuickInno = hasTempConfig ? tempconfig.QuickInno : P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist && hasDelins;
-
-            return config;
+            return $"{craft.CraftLevel}/{craft.CraftProgress}/{craft.CraftQualityMax}/{craft.CraftDurability}-{craft.StatCraftsmanship}/{craft.StatControl}/{craft.StatCP}-{(craft.CraftExpert ? "Ex" : "St")}/{craft.InitialQuality}/{(craft.Specialist ? "Sp" : "Re")}/Steady{Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}-{(config.UseHeartAndSoul ? "1" : "0")}/{(config.UseQuickInno ? "1" : "0")}/{(config.HasManipulation ? "1" : "0")}/{(config.EnsureReliability ? "1" : "0")}/{(config.BackloadProgress ? "1" : "0")}";
         }
 
-        public static IEnumerable<CraftState> AllValidCrafts(string key)
+        public static string GetKeyForLookups(RaphaelOptions opt)
         {
-            var stats = KeyParts(key);
-            var recipes = LuminaSheets.RecipeSheet.Values.Where(x => x.RecipeLevelTable.Value.ClassJobLevel == stats.Level);
+            return $"{opt.Level}/{opt.Progress}/{opt.QualityMax}/{opt.Durability}-{opt.MinCraftsmanship}/{opt.MinControl}/{opt.MinCP}-{(opt.IsExpert ? "Ex" : "St")}/{opt.InitialQuality}/{(opt.IsSpecialist ? "Sp" : "Re")}/Steady{opt.SteadyHandUses}-{(opt.SolutionConfig.UseHeartAndSoul ? "1" : "0")}/{(opt.SolutionConfig.UseQuickInno ? "1" : "0")}/{(opt.SolutionConfig.HasManipulation ? "1" : "0")}/{(opt.SolutionConfig.EnsureReliability ? "1" : "0")}/{(opt.SolutionConfig.BackloadProgress ? "1" : "0")}";
+        }
+
+        public static IEnumerable<CraftState> AllValidCrafts(RaphaelOptions key)
+        {
+            var recipes = LuminaSheets.RecipeSheet.Values.Where(x => x.RecipeLevelTable.Value.ClassJobLevel == key.Level);
             foreach (var recipe in recipes)
             {
                 var state = Crafting.BuildCraftStateForRecipe(default, (Job)((uint)Job.CRP + recipe.CraftType.RowId), recipe);
                 if (state.StatLevel < 7) continue;
 
-                if (stats.Prog == state.CraftProgress &&
-                    stats.Qual == state.CraftQualityMax &&
-                    stats.Dur == state.CraftDurability)
+                if (key.Progress == state.CraftProgress &&
+                    key.QualityMax == state.CraftQualityMax &&
+                    key.Durability == state.CraftDurability)
                     yield return state;
             }
         }
 
-        public static (int Level, int Prog, int Qual, int Dur, int Initial, int Crafts, int Control, int CP, bool SP) KeyParts(string key)
+        public static RaphaelSolutionConfig GetRaphConfig(CraftState craft, bool checkDelins = false)
+        {
+            var globalRaph = P.Config.RaphaelSolverConfig;
+            var hasDelins = Crafting.DelineationCount() > 0;
+            return new RaphaelSolutionConfig()
+            {
+                HasManipulation = craft.UnlockedManipulation,
+                EnsureReliability = globalRaph.AllowEnsureReliability && globalRaph.EnsureReliability && !craft.CraftExpert,
+                BackloadProgress = globalRaph.AllowBackloadProgress && globalRaph.BackloadProgress,
+                UseHeartAndSoul = globalRaph.ShowSpecialistSettings && globalRaph.UseHeartAndSoul && craft.Specialist && (!checkDelins || hasDelins),
+                UseQuickInno = globalRaph.ShowSpecialistSettings && globalRaph.UseQuickInno && craft.Specialist && (!checkDelins || hasDelins),
+            };
+        }
+
+        public static bool HasSolution(CraftState craft, out Macro? raphaelSolution) => HasSolution(craft, null, out raphaelSolution);
+
+        public static bool HasSolution(CraftState craft, RaphaelSolutionConfig? config, out Macro? raphaelSolution)
+        {
+            config ??= GetRaphConfig(craft);
+
+            var key = GetOptions(craft, config);
+            raphaelSolution = null;
+            var hasKey = P.Config.RaphaelSolverCacheV6.ContainsKey(key);
+            if (hasKey)
+            {
+                raphaelSolution = P.Config.RaphaelSolverCacheV6[key];
+                return true;
+            }
+            else
+                return false;
+        }
+
+        public static bool InProgress(CraftState craft, RaphaelSolutionConfig config) => Tasks.TryGetValue(GetOptions(craft, config), out var _);
+
+        public static bool InProgressAny() => !Tasks.IsEmpty;
+
+        internal static bool CLIExists()
+        {
+            return File.Exists(Path.Join(Path.GetDirectoryName(Svc.PluginInterface.AssemblyLocation.FullName), "raphael-cli.bin"));
+        }
+
+        public static void DrawRaphaelDropdown(CraftState craft, bool liveStats = true)
+        {
+            var config = P.Config.RecipeConfigs.GetValueOrDefault(craft.RecipeId) ?? new();
+            if (CLIExists())
+            {
+                // snapshot the current generation settings in case they change before the next generate
+                var curConfig = GetRaphConfig(craft).JSONClone();
+                var hasSolution = HasSolution(craft, curConfig, out var solution);
+                var opts = GetOptions(craft, curConfig);
+                var keyStr = GetTextKey(craft, curConfig);
+
+                var solverIsRaph = config.SolverIsRaph;
+                if (!hasSolution)
+                {
+                    if (solverIsRaph)
+                        ImGuiEx.TextCentered(ImGuiColors.DalamudRed, "No Raphael solution generated");
+                    if (P.Config.RaphaelSolverConfig.AutoGenerate && CraftingProcessor.GetAvailableSolversForRecipe(craft, true).Any() && (!craft.CraftExpert || (craft.CraftExpert && P.Config.RaphaelSolverConfig.GenerateOnExperts)))
+                    {
+                        Build(craft, curConfig);
+                    }
+                }
+
+                ImGui.Separator();
+
+                var inProgress = InProgress(craft, curConfig);
+
+                if (inProgress)
+                    ImGui.BeginDisabled();
+
+                var showReliability = P.Config.RaphaelSolverConfig.AllowEnsureReliability && !craft.CraftExpert;
+                var showBackload = P.Config.RaphaelSolverConfig.AllowBackloadProgress;
+                var showSpecialist = P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist;
+
+                if (showReliability || showBackload || showSpecialist)
+                {
+                    ImGuiEx.Text(ImGuiColors.DalamudGrey, "Raphael Solver Settings");
+                }
+
+                if (showReliability)
+                {
+                    ImGui.Checkbox($"Ensure 100% reliability##{keyStr}Reliability", ref P.Config.RaphaelSolverConfig.EnsureReliability);
+                    ImGuiComponents.HelpMarker("Try to find a solution that works for any permutation of per-step crafting conditions. EXTREMELY RAM AND CPU INTENSIVE NO SUPPORT WILL BE GIVEN IF YOU HAVE THIS ON");
+                }
+                if (showBackload)
+                {
+                    ImGui.Checkbox($"Backload progress##{keyStr}Progress", ref P.Config.RaphaelSolverConfig.BackloadProgress);
+                    ImGuiComponents.HelpMarker($"Find a solution that finishes quality before starting on progress. Useful for simple expert recipes where the Malleable condition might otherwise cause an early finish.");
+                }
+                if (showSpecialist)
+                {
+                    P.PluginUi.ExpertSettingsUI.CheckboxWithIcons($"{keyStr}HS", ref P.Config.RaphaelSolverConfig.UseHeartAndSoul, "Allow [s!HeartAndSoul]");
+                    ImGuiComponents.HelpMarker($"The generated macro will require one crafter's delineation per craft.");
+
+                    P.PluginUi.ExpertSettingsUI.CheckboxWithIcons($"{keyStr}QI", ref P.Config.RaphaelSolverConfig.UseQuickInno, "Allow [s!QuickInnovation]");
+                    ImGuiComponents.HelpMarker($"The generated macro will require one crafter's delineation per craft.");
+                }
+
+                if (showReliability || showBackload || showSpecialist)
+                {
+                    ImGui.Dummy(new Vector2(0, 5f));
+                }
+
+                if (inProgress)
+                    ImGui.EndDisabled();
+
+                if (craft.StatLevel >= 7) // can't run the raphael generator without Master's Mend
+                {
+                    if (!inProgress)
+                    {
+                        string verb = hasSolution ? "Rebuild" : "Build";
+                        ImGuiEx.LineCentered(() =>
+                        {
+                            if (ImGui.Button($"{verb} Raphael Solution", new Vector2(config.GetLargestName(), 25f.Scale())))
+                            {
+                                Build(craft, curConfig);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        ImGuiEx.LineCentered(() =>
+                        {
+                            if (ImGui.Button("Cancel Raphael Generation", new Vector2(config.GetLargestName(), 25f.Scale())))
+                            {
+                                Tasks.TryRemove(opts, out var task);
+                                task.Cancellation.Cancel();
+                            }
+                        });
+                    }
+                }
+
+                if (curConfig.EnsureReliability && ImGui.IsItemHovered())
+                {
+                    ImGui.BeginTooltip();
+                    ImGui.Text("\"Ensure 100% reliability\" is enabled, which is very CPU- and RAM-intensive.\nDue to this, no support will be given if you have issues.");
+                    ImGui.EndTooltip();
+                }
+
+                if (curConfig.UseHeartAndSoul || curConfig.UseQuickInno)
+                {
+                    ImGuiEx.Text(ImGuiColors.DalamudYellow, "Specialist actions are enabled. This can slow down the solver a lot.");
+                }
+
+                if (inProgress)
+                {
+                    ImGuiEx.TextCentered("Generating...");
+                }
+
+                ImGui.Dummy(new Vector2(0, 2f));
+            }
+        }
+
+        public static int GetNewID(Configuration? config = null)
+        {
+            config ??= P.Config;
+
+            var rng = new Random();
+            var id = rng.Next(50001, 10000000);
+            while (config.RaphaelSolverCacheV6.Values.FirstOrDefault(m => m.ID == id) != null)
+                id = rng.Next(50001, 10000000);
+            return id;
+        }
+
+        // deprecated (string keys are now RaphaelOptions objects), should only be used when converting from v5
+        public static (int Level, int Prog, int Qual, int Dur, int Initial, int Crafts, int Control, int CP, bool SP, bool IsEx, int Hands) V5KeyParts(string key)
         {
             var parts = key.Split('/');
 
@@ -327,133 +511,214 @@ namespace Artisan.CraftingLogic.Solvers
             int.TryParse(parts[5].Split('-')[0], out var cp);
             int.TryParse(parts[6], out var initial);
             var sp = parts[7] == "Sp";
+            var isEx = parts[5].Split('-')[1] == "Ex";
+            var hands = 0;
+            if (parts.Length >= 9)
+                hands = parts[8].Substring(6).ParseInt() ?? 0;
 
-            return (lvl, prog, qual, dur, initial, crafts, ctrl, cp, sp);
+            return (lvl, prog, qual, dur, initial, crafts, ctrl, cp, sp, isEx, hands);
         }
 
-        public static bool HasSolution(CraftState craft, out MacroSolverSettings.Macro? raphaelSolutionConfig)
+        public static void LoadRaphaelCache(Configuration config, bool deleteV5)
         {
-            var thisKey = GetKey(craft);
-            raphaelSolutionConfig = null;
-            var sol = P.Config.RaphaelSolverCacheV5.FirstOrNull(x => x.Key == thisKey);
-            if (sol != null)
+            // keeping "deletev5" as a param, currently false, so we can delete it in the future to reduce config file size
+            // v5 cache won't be loaded after being converted if a v6 cache exists, just keeping it as a backup right now
+
+            // either load the current cache or, if missing, try to convert a v5 cache
+            var v6cache = LoadRaphaelCacheFromFile(config);
+            if (!v6cache.IsEmpty)
             {
-                raphaelSolutionConfig = sol.Value.Value;
-                return true;
+                Svc.Log.Info($"Loaded existing Raphael cache from file ({v6cache.Keys.Count} entries)");
+                config.RaphaelSolverCacheV6 = v6cache;
             }
-            else
+            else if (!config.RaphaelSolverCacheV5.IsEmpty && !config.RaphaelV5Converted)
             {
-                return false;
+                Svc.Log.Info($"Updating Raphael cache from v5 to v6 ({config.RaphaelSolverCacheV5.Keys.Count} entries)");
+                ConvertV5ToV6(config);
+            }
+
+            if (deleteV5)
+                config.RaphaelSolverCacheV5.Clear();
+        }
+
+        private static ConcurrentDictionary<RaphaelOptions, MacroSolverSettings.Macro> LoadRaphaelCacheFromFile(Configuration config)
+        {
+            var file = new FileInfo(Path.Combine(config.ConfigDirectory.FullName, RaphaelFileName));
+            if (!file.Exists)
+                return [];
+
+            try
+            {
+                Svc.Log.Information("Loading Raphael cache from file...");
+                var stringCache = RaphaelCache.ReadCacheFile(file);
+                if (stringCache.Count > 0)
+                    return RaphaelCache.ConvertFromStringCache(stringCache);
+            }
+            catch (Exception e)
+            {
+                Svc.Log.Error($"Error reading raphael cache file \"{file.FullName}\":\n{e}");
+            }
+
+            return [];
+        }
+
+        public static void WriteRaphaelCache(Configuration config)
+        {
+            var file = new FileInfo(Path.Combine(config.ConfigDirectory.FullName, RaphaelFileName));
+            try
+            {
+                var stringCache = RaphaelCache.ConvertToStringCache(config.RaphaelSolverCacheV6);
+                var json = JObject.FromObject(stringCache).ToString();
+                File.WriteAllText(file.FullName, json);
+                P.PluginUi.RaphaelCacheUI.Table = null;
+            }
+            catch (Exception e)
+            {
+                Svc.Log.Error($"Error saving raphael cache file \"{file.FullName}\":\n{e}");
             }
         }
-
-        public static bool InProgress(CraftState craft) => Tasks.TryGetValue(GetKey(craft), out var _);
-
-        public static bool InProgressAny() => Tasks.Any();
-
-        internal static bool CLIExists()
+        public static void ConvertV5ToV6(Configuration config)
         {
-            return File.Exists(Path.Join(Path.GetDirectoryName(Svc.PluginInterface.AssemblyLocation.FullName), "raphael-cli.bin"));
+            ConcurrentDictionary<RaphaelOptions, MacroSolverSettings.Macro> v6Cache = [];
+
+            // check if the current character has Manipulation on every job as a guess for v5 solves
+            bool hasAllManip = true;
+            List<Job> allJobs = [Job.CRP, Job.BSM, Job.ARM, Job.GSM, Job.LTW, Job.WVR, Job.ALC, Job.CUL];
+            foreach (Job j in allJobs)
+            {
+                hasAllManip &= CharacterInfo.IsManipulationUnlocked(j);
+            }
+
+            foreach (var (key, macro) in config.RaphaelSolverCacheV5)
+            {
+                var stats = V5KeyParts(key);
+
+                // try to guess some raph generation settings based on macro steps
+                bool v6HS = false;
+                bool v6QI = false;
+                bool v6Manip = hasAllManip;
+                bool v6Backload = true;
+
+                bool hasProgress = false;
+                foreach (MacroStep step in macro.Steps)
+                {
+                    if (step.Action == Skills.HeartAndSoul)
+                        v6HS = true;
+                    if (step.Action == Skills.QuickInnovation)
+                        v6QI = true;
+                    if (step.Action == Skills.Manipulation)
+                        v6Manip = true;
+
+                    // not backloading progress if any quality action happens after any progress action
+                    if (MacroSolver.ActionIsProgress(step.Action))
+                        hasProgress = true;
+                    if (hasProgress && MacroSolver.ActionIsQuality(step.Action))
+                        v6Backload = false;
+                }
+
+                string newKey = $"{key}-{(v6HS ? "1" : "0")}/{(v6QI ? "1" : "0")}/{(v6Manip ? "1" : "0")}/0/{(v6Backload ? "1" : "0")}";
+                RaphaelOptions newOpts = new()
+                {
+                    SkipQualityIfMet = macro.Options.SkipQualityIfMet,
+                    UpgradeProgressActions = macro.Options.UpgradeProgressActions,
+                    UpgradeQualityActions = macro.Options.UpgradeQualityActions,
+                    MinCP = stats.CP,
+                    MinControl = stats.Control,
+                    MinCraftsmanship = stats.Crafts,
+                    Level = stats.Level,
+                    Progress = stats.Prog,
+                    QualityMax = stats.Qual,
+                    Durability = stats.Dur,
+                    IsExpert = stats.IsEx,
+                    InitialQuality = stats.Initial,
+                    IsSpecialist = stats.SP,
+                    SteadyHandUses = stats.Hands,
+                    SolutionConfig = new RaphaelSolutionConfig()
+                    {
+                        UseHeartAndSoul = v6HS,
+                        UseQuickInno = v6QI,
+                        HasManipulation = v6Manip,
+                        EnsureReliability = false,  // better to regenerate than to assume
+                        BackloadProgress = v6Backload
+                    }
+                };
+
+                Macro v6Macro = new()
+                {
+                    ID = GetNewID(config),  // v5 didn't enforce ID uniqueness so we'll assign new ones just in case
+                    Name = newKey,
+                    Steps = macro.Steps,
+                    Options = newOpts
+                };
+
+                v6Cache[newOpts] = v6Macro;
+            }
+
+            config.RaphaelSolverCacheV6 = v6Cache;
+            config.RaphaelV5Converted = true;
         }
 
-        public static void DrawRaphaelDropdown(CraftState craft, bool liveStats = true)
+        public static Dictionary<string, MacroSolverSettings.Macro> ConvertToStringCache(ConcurrentDictionary<RaphaelOptions, MacroSolverSettings.Macro> cache)
         {
-            var config = P.Config.RecipeConfigs.GetValueOrDefault(craft.RecipeId) ?? new();
-            if (CLIExists())
+            Dictionary<string, MacroSolverSettings.Macro> stringCache = [];
+
+            foreach (var (key, macro) in cache)
             {
-                var hasSolution = HasSolution(craft, out var solution);
-                var key = GetKey(craft);
+                JsonSerializerOptions options = new() { IncludeFields = true };
+                string jsonKey = JsonSerializer.Serialize(key, options);
+                stringCache[jsonKey] = macro;
+            }
 
-                if (!TempConfigs.ContainsKey(key))
-                {
-                    TempConfigs.Add(key, new());
-                    TempConfigs[key].EnsureReliability = P.Config.RaphaelSolverConfig.AllowEnsureReliability && !craft.CraftExpert;
-                    TempConfigs[key].BackloadProgress = P.Config.RaphaelSolverConfig.AllowBackloadProgress;
-                    TempConfigs[key].HeartAndSoul = P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist;
-                    TempConfigs[key].QuickInno = P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist;
-                }
+            return stringCache;
+        }
 
-                var opt = CraftingProcessor.GetAvailableSolversForRecipe(craft, true).FirstOrNull(x => x.Name == $"Raphael Recipe Solver");
-                var solverIsRaph = config.SolverIsRaph;
-                if (!hasSolution)
-                {
-                    if (solverIsRaph)
-                        ImGuiEx.TextCentered(ImGuiColors.DalamudRed, "No Raphael Solution Generated.");
-                    if (P.Config.RaphaelSolverConfig.AutoGenerate && CraftingProcessor.GetAvailableSolversForRecipe(craft, true).Any() && (!craft.CraftExpert || (craft.CraftExpert && P.Config.RaphaelSolverConfig.GenerateOnExperts)))
-                    {
-                        Build(craft, TempConfigs[key]);
-                    }
-                }
+        public static ConcurrentDictionary<RaphaelOptions, MacroSolverSettings.Macro> ConvertFromStringCache(Dictionary<string, MacroSolverSettings.Macro> stringCache)
+        {
+            ConcurrentDictionary<RaphaelOptions, MacroSolverSettings.Macro> cache = [];
 
-                ImGui.Separator();
+            foreach (var (key, macro) in stringCache)
+            {
+                var json = JObject.Parse(key);
+                var parsedKey = json.ToObject<RaphaelOptions>() ?? new();
+                if (parsedKey.Level > 0)
+                    cache[parsedKey] = macro;
+            }
 
-                var inProgress = InProgress(craft);
+            return cache;
+        }
 
-                if (inProgress)
-                    ImGui.BeginDisabled();
+        public static Dictionary<string, MacroSolverSettings.Macro> ReadCacheFile(FileInfo file)
+        {
+            if (!file.Exists)
+                return [];
 
-                if (P.Config.RaphaelSolverConfig.AllowEnsureReliability && !craft.CraftExpert)
-                    ImGui.Checkbox($"Ensure reliability##{key}Reliability", ref TempConfigs[key].EnsureReliability);
-                if (P.Config.RaphaelSolverConfig.AllowBackloadProgress)
-                    ImGui.Checkbox($"Backload progress##{key}Progress", ref TempConfigs[key].BackloadProgress);
-                if (P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist)
-                    ImGui.Checkbox($"Allow heart and soul usage##{key}HS", ref TempConfigs[key].HeartAndSoul);
-                if (P.Config.RaphaelSolverConfig.ShowSpecialistSettings && craft.Specialist)
-                    ImGui.Checkbox($"Allow quick innovation usage##{key}QI", ref TempConfigs[key].QuickInno);
-
-                if (inProgress)
-                    ImGui.EndDisabled();
-
-                if (craft.StatLevel >= 7)
-                {
-                    if (!inProgress)
-                    {
-                        ImGuiEx.LineCentered(() =>
-                        {
-                            if (ImGui.Button("Build Raphael Solution", new Vector2(config.GetLargestName(), 25f.Scale())))
-                            {
-                                Build(craft, TempConfigs[key]);
-                            }
-                        });
-                    }
-                    else
-                    {
-                        ImGuiEx.LineCentered(() =>
-                        {
-                            if (ImGui.Button("Cancel Raphael Generation", new Vector2(config.GetLargestName(), 25f.Scale())))
-                            {
-                                Tasks.TryRemove(key, out var task);
-                                task.Cancellation.Cancel();
-                            }
-                        });
-                    }
-                }
-
-                if (TempConfigs[key].EnsureReliability && ImGui.IsItemHovered())
-                {
-                    ImGui.BeginTooltip();
-                    ImGui.Text("Ensuring quality is enabled, no support shall be provided when its enabled\nDue to problems that can be caused.");
-                    ImGui.EndTooltip();
-                }
-
-                if (TempConfigs[key].HeartAndSoul || TempConfigs[key].QuickInno)
-                {
-                    ImGui.Text("Specialist actions are enabled, this can slow down the solver a lot.");
-                }
-
-                if (inProgress)
-                {
-                    ImGuiEx.TextCentered("Generating...");
-                }
+            try
+            {
+                var raw = File.ReadAllText(file.FullName);
+                var json = JObject.Parse(raw);
+                var parsed = json.ToObject<Dictionary<string, MacroSolverSettings.Macro>>() ?? [];
+                return parsed;
+            }
+            catch (Exception e)
+            {
+                Svc.Log.Error($"Error reading raphael cache file \"{file.FullName}\":\n{e}");
+                return [];
             }
         }
     }
 
     public class RaphaelSolverSettings
     {
+        // these enable the relevant checkboxes on the crafting log mini-menu
         public bool AllowEnsureReliability = false;
         public bool AllowBackloadProgress = true;
         public bool ShowSpecialistSettings = false;
+        // these track the actual values of those checkboxes
+        public bool EnsureReliability = false;
+        public bool BackloadProgress = true;
+        public bool UseHeartAndSoul = false;
+        public bool UseQuickInno = false;
+
         public bool ExactCraftsmanship = false;
         public bool AutoGenerate = false;
         public bool AutoSwitch = false;
@@ -490,10 +755,9 @@ namespace Artisan.CraftingLogic.Solvers
                 changed |= ImGui.SliderInt("Maximum threads (0 for all)", ref MaximumThreads, 0, Environment.ProcessorCount);
                 ImGuiComponents.HelpMarker("By default the Raphael generator uses everything it can (setting = 0), but on lower-end machines you might need to use less CPU at the cost of speed.");
 
-                changed |= ImGui.Checkbox("Ensure 100% reliability in macro generation", ref AllowEnsureReliability);
-                //ImGui.PushTextWrapPos(0);
+                changed |= ImGui.Checkbox("Allow \"Ensure 100% reliability\"", ref AllowEnsureReliability);
+                ImGuiComponents.HelpMarker("Enables a checkbox on the Crafting Log mini-menu. This setting will try to find a solution that works for any permutation of per-step crafting conditions.");
                 ImGuiEx.TextWrapped(new System.Numerics.Vector4(255, 0, 0, 1), "Ensuring reliability may not always work and is very CPU and RAM intensive. 16GB+ of spare RAM is recommended. NO SUPPORT SHALL BE GIVEN IF YOU HAVE THIS ON");
-                //ImGui.PopTextWrapPos();
 
                 ImGui.Dummy(new Vector2(0, 2f));
                 changed |= ImGui.SliderInt("Macro generation timeout (minutes)", ref TimeOutMins, 1, 15);
@@ -531,13 +795,12 @@ namespace Artisan.CraftingLogic.Solvers
                 ImGui.Dummy(new Vector2(0, 2f));
                 ImGui.Indent();
 
-                ImGui.TextWrapped($"These settings will display new macro generation options for each recipe.");
-
                 ImGui.Dummy(new Vector2(0, 2f));
-                changed |= ImGui.Checkbox($"Allow backloading of {ProgressString.ToLower()}", ref AllowBackloadProgress);
-                ImGuiComponents.HelpMarker($"When enabled, this will ensure {QualityString.ToLower()} is finished before starting on {ProgressString.ToLower()}. Useful for simple expert recipes where the Malleable condition might otherwise cause an early finish.");
+                changed |= ImGui.Checkbox($"Allow \"Backload {ProgressString.ToLower()}\"", ref AllowBackloadProgress);
+                ImGuiComponents.HelpMarker($"Enables a checkbox on the Crafting Log mini-menu. This setting ensures that {QualityString.ToLower()} is finished before starting on {ProgressString.ToLower()}. Useful for simple expert recipes where the Malleable condition might otherwise cause an early finish.");
 
                 changed |= ImGui.Checkbox("Allow specialist actions when available", ref ShowSpecialistSettings);
+                ImGuiComponents.HelpMarker($"Enables checkboxes on the Crafting Log mini-menu that let the solver use {Skills.HeartAndSoul.NameOfAction()} and {Skills.QuickInnovation.NameOfAction()}.");
 
                 changed |= P.PluginUi.ExpertSettingsUI.SliderIntWithIcons("MaxStellarHand", ref MaxStellarHand, 0, 2, "Max [s!SteadyHand] uses per craft");
                 P.PluginUi.ExpertSettingsUI.HelpMarkerWithIcons(["This setting only applies to Cosmic Exploration recipes on missions with [s!SteadyHand].", "The Raphael solver will use UP TO this many charges depending on the recipe's difficulty."]);
@@ -581,9 +844,10 @@ namespace Artisan.CraftingLogic.Solvers
                     ImGui.Unindent();
                 }
 
-                if (ImGui.Button($"Clear raphael macro cache (Currently {P.Config.RaphaelSolverCacheV5.Count} stored)"))
+                ImGui.Dummy(new Vector2(0, 5f));
+                if (ImGui.Button($"Clear Raphael Macro Cache (currently {P.Config.RaphaelSolverCacheV6.Count} stored)"))
                 {
-                    P.Config.RaphaelSolverCacheV5.Clear();
+                    P.Config.RaphaelSolverCacheV6.Clear();
                     changed |= true;
                 }
 
@@ -599,17 +863,26 @@ namespace Artisan.CraftingLogic.Solvers
 
     public class RaphaelSolutionConfig
     {
+        public bool HasManipulation = false;
         public bool EnsureReliability = false;
         public bool BackloadProgress = false;
-        public bool HeartAndSoul = false;
-        public bool QuickInno = false;
-        public string Macro = string.Empty;
+        public bool UseHeartAndSoul = false;
+        public bool UseQuickInno = false;
+    }
 
-        public int MinCP = 0;
-        public int MinControl = 0;
-        public int ExactCraftsmanship = 0;
+    public class RaphaelOptions : MacroOptions
+    {
+        public int Level = 0;
+        public int Progress = 0;
+        public int QualityMax = 0;
+        public int Durability = 0;
+        public bool IsExpert = false;
+        public int InitialQuality = 0;
+        public bool IsSpecialist = false;
+        public int SteadyHandUses = 0;
+        public RaphaelSolutionConfig SolutionConfig = new();
 
-        [NonSerialized]
-        public bool HasChanges = false;
+        public override int GetHashCode() => RaphaelCache.GetKeyForLookups(this).GetHashCode();
+        public override bool Equals(object obj) => obj != null && obj.GetHashCode() == this.GetHashCode();
     }
 }

--- a/Artisan/GameInterop/Crafting.cs
+++ b/Artisan/GameInterop/Crafting.cs
@@ -377,24 +377,23 @@ public static unsafe class Crafting
             if (P.Config.RecipeConfigs.TryGetValue(CurRecipe.Value.RowId, out var rc))
             {
                 Svc.Log.Debug($"Checking for delins");
-                if (CurCraft.Specialist && !EnoughDelinsForCraft(rc, CurCraft, out _))
+                if (CurCraft.Specialist && !EnoughDelinsForCraft(rc, CurCraft, out _) && !rc.CurrentSolverType.Contains("Raphael"))
                     CurCraft.Specialist = false;
 
                 Svc.Log.Debug("Updating Steady Hand Charges");
                 if (CurCraft.MissionHasSteadyHand)
                     CurCraft.CurrentSteadyHandCharges = SteadyHandCharges();
 
-                if (rc.CurrentSolverType.Contains("Raphael") && !RaphaelCache.HasSolution(CurCraft, out _))
+                var raphConfig = RaphaelCache.GetRaphConfig(CurCraft, true);
+                if (rc.CurrentSolverType.Contains("Raphael") && !RaphaelCache.HasSolution(CurCraft, raphConfig, out _))
                 {
                     if (RaphaelCache.CLIExists())
                     {
-                        var key = RaphaelCache.GetKey(CurCraft);
+                        var key = RaphaelCache.GetOptions(CurCraft, raphConfig);
                         if (RaphaelCache.Tasks.ContainsKey(key))
                             return State.WaitStart;
 
                         Svc.Log.Debug("Raphael set as config but has no solution, generating now...");
-                        var raphConfig = RaphaelCache.GetConfigFromTempOrDefault(CurCraft);
-
                         RaphaelCache.Build(CurCraft, raphConfig, true);
                         return State.WaitStart; // wait for solution to be ready
                     }
@@ -594,8 +593,7 @@ public static unsafe class Crafting
         }
         else if (config.CurrentSolverType.Contains("Raphael"))
         {
-            var key = RaphaelCache.GetKey(craft);
-            if (RaphaelCache.HasSolution(craft, out var macro))
+            if (RaphaelCache.HasSolution(craft, RaphaelCache.GetRaphConfig(craft, true), out var macro))
             {
                 numReq = macro.Steps.Count(x => x.Action is Skills.CarefulObservation or Skills.HeartAndSoul or Skills.QuickInnovation);
                 if (numReq > Crafting.DelineationCount())

--- a/Artisan/UI/KTK/NativeCraftAll.cs
+++ b/Artisan/UI/KTK/NativeCraftAll.cs
@@ -1,7 +1,5 @@
 ﻿using Artisan.Autocraft;
 using Artisan.RawInformation;
-using ECommons.DalamudServices;
-using ECommons.ImGuiMethods;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using KamiToolKit.Controllers;
 using KamiToolKit.Nodes;

--- a/Artisan/UI/KTK/NativeCraftAll.cs
+++ b/Artisan/UI/KTK/NativeCraftAll.cs
@@ -1,5 +1,6 @@
 ﻿using Artisan.Autocraft;
 using Artisan.RawInformation;
+using ECommons.DalamudServices;
 using ECommons.ImGuiMethods;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using KamiToolKit.Controllers;
@@ -122,6 +123,8 @@ namespace Artisan.UI.KTK
 
         private void OnRefresh(AtkUnitBase* addon)
         {
+            if (!P.Config.UseNativeButtons) return;
+
             var text = addon->NameString == "WKSRecipeNotebook" ? addon->GetTextNodeById(34)->NodeText.ToString() : addon->GetTextNodeById(78)->NodeText.ToString();
             SynthesizeableCount = text == "" ? 0 : Convert.ToInt32(text.GetNumbers());
 

--- a/Artisan/UI/MacroEditor.cs
+++ b/Artisan/UI/MacroEditor.cs
@@ -97,11 +97,11 @@ namespace Artisan.UI
                     {
                         if (raphael_cache)
                         {
-                            var copy = P.Config.RaphaelSolverCacheV5.Where(kv => kv.Value == SelectedMacro);
+                            var copy = P.Config.RaphaelSolverCacheV6.Where(kv => kv.Value == SelectedMacro);
                             //really should be just one but is it for sure??
                             foreach (var kv in copy)
                             {
-                                P.Config.RaphaelSolverCacheV5.TryRemove(kv);
+                                P.Config.RaphaelSolverCacheV6.TryRemove(kv);
                             }
                         }
                         else

--- a/Artisan/UI/PluginUI.cs
+++ b/Artisan/UI/PluginUI.cs
@@ -4,6 +4,7 @@ using Artisan.CraftingLogic;
 using Artisan.FCWorkshops;
 using Artisan.RawInformation;
 using Artisan.RawInformation.Character;
+using Artisan.UI.Tables;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
@@ -32,7 +33,7 @@ namespace Artisan.UI
     {
         public event EventHandler<bool>? CraftingWindowStateChanged;
         public ExpertSolverSettingsUI ExpertSettingsUI = new();
-
+        public RaphaelCacheUI RaphaelCacheUI = new();
 
         private bool visible = false;
         public OpenWindow OpenWindow { get; set; }

--- a/Artisan/UI/RaphaelCacheUI.cs
+++ b/Artisan/UI/RaphaelCacheUI.cs
@@ -4,19 +4,21 @@ using ECommons.ImGuiMethods;
 using Dalamud.Bindings.ImGui;
 using System.Linq;
 using System.Numerics;
+using Artisan.UI.Tables;
+using ECommons;
+using Artisan.CraftingLogic.Solvers;
 
 namespace Artisan.UI
 {
-    internal static class RaphaelCacheUI
+    internal class RaphaelCacheUI
     {
-        private static string _search = string.Empty;
-        private static bool _oldVersion = false;
-        internal static void Draw()
+        public RaphaelCacheTable? Table;
+
+        internal void Draw()
         {
             try
             {
-                ImGui.TextWrapped("This tab will allow you to view macros in the Raphael integration cache.");
-                ImGui.Separator();
+                ImGui.TextWrapped("This tab shows all of the currently saved Raphael-generated macros.");
 
                 if (Svc.ClientState.IsLoggedIn && Crafting.CurState is not Crafting.State.IdleNormal and not Crafting.State.IdleBetween)
                 {
@@ -25,65 +27,42 @@ namespace Artisan.UI
                 }
                 ImGui.Spacing();
 
-                if (ImGui.RadioButton("Old Cache (not in use)", _oldVersion))
-                    _oldVersion = true;
+                ImGui.TextWrapped($"Currently saved macros: {P.Config.RaphaelSolverCacheV6.Keys.Count}");
+                ImGui.Spacing();
+
+                if (ImGui.BeginChild("##selector", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - 32f.Scale()), true))
+                {
+                    // todo: search by recipe?
+                    if (Table == null)
+                    {
+                        var cacheList = P.Config.RaphaelSolverCacheV6.Keys.ToList();
+                        Table = new(cacheList);
+                    }
+                    Table.Draw(ImGui.GetTextLineHeightWithSpacing() - 4f);
+                }
+                ImGui.EndChild();
+
+                var filterActive = Table.FilteredItems.Count != 0 && Table.FilteredItems.Count != P.Config.RaphaelSolverCacheV6.Keys.Count;
+                var filterCount = filterActive ? $"{Table.FilteredItems.Count} " : "";
+
+                if (!filterActive) ImGui.BeginDisabled();
+                if (ImGuiEx.ButtonCtrl($"Delete {filterCount}Filtered Macros", new Vector2(ImGui.GetContentRegionAvail().X / 2, ImGui.GetContentRegionAvail().Y)))
+                {
+                    var toDelete = Table.FilteredItems.JSONClone();
+                    foreach ((RaphaelOptions key, int _) in toDelete)
+                    {
+                        P.Config.RaphaelSolverCacheV6.TryRemove(key, out _);
+                    }
+                    Table.FilteredItems.Clear();
+                    P.Config.Save();
+                }
+                if (!filterActive) ImGui.EndDisabled();
+
                 ImGui.SameLine();
-                if (ImGui.RadioButton("New Cache", !_oldVersion))
-                    _oldVersion = false;
 
-                ImGui.InputText($"Search", ref _search, 300);
-
-                if (!_oldVersion)
+                if (ImGuiEx.ButtonCtrl($"Delete Entire Cache", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y)))
                 {
-
-                    if (ImGui.BeginChild("##selector", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - 32f.Scale()), true))
-                    {
-                        ImGuiEx.TextUnderlined($"Level/Progress/Quality/Durability-Craftsmanship/Control/CP-Type/Initial Quality");
-                        foreach (var key in P.Config.RaphaelSolverCacheV5.Keys)
-                        {
-                            var m = P.Config.RaphaelSolverCacheV5[key];
-                            if (!m.Name.Contains(_search, System.StringComparison.CurrentCultureIgnoreCase)) continue;
-                            var selected = ImGui.Selectable($"{m.Name}###{m.ID}");
-
-                            if (selected && !P.ws.Windows.Any(x => x.WindowName.Contains(m.ID.ToString())))
-                            {
-                                new MacroEditor(m, true);
-                            }
-                        }
-
-                    }
-                    ImGui.EndChild();
-
-                }
-                else
-                {
-
-                    if (ImGui.BeginChild("##selector", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - 32f.Scale()), true))
-                    {
-                        ImGuiEx.TextUnderlined($"Level/Progress/Quality/Durability-Craftsmanship/Control/CP-Type");
-                        foreach (var key in P.Config.RaphaelSolverCacheV4.Keys)
-                        {
-                            var m = P.Config.RaphaelSolverCacheV4[key];
-                            if (!m.Name.Contains(_search, System.StringComparison.CurrentCultureIgnoreCase)) continue;
-                            var selected = ImGui.Selectable($"{m.Name}###{m.ID}");
-
-                            if (selected && !P.ws.Windows.Any(x => x.WindowName.Contains(m.ID.ToString())))
-                            {
-                                new MacroEditor(m, true);
-                            }
-                        }
-
-                    }
-                    ImGui.EndChild();
-
-                }
-
-                if (ImGui.Button("Clear This Raphael Cache (Hold Ctrl)", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y)) && ImGui.GetIO().KeyCtrl)
-                {
-                    if (_oldVersion)
-                        P.Config.RaphaelSolverCacheV4.Clear();
-                    else
-                        P.Config.RaphaelSolverCacheV5.Clear();
+                    P.Config.RaphaelSolverCacheV6.Clear();
                     P.Config.Save();
                 }
             }

--- a/Artisan/UI/RaphaelCacheUI.cs
+++ b/Artisan/UI/RaphaelCacheUI.cs
@@ -46,7 +46,7 @@ namespace Artisan.UI
                 var filterCount = filterActive ? $"{Table.FilteredItems.Count} " : "";
 
                 if (!filterActive) ImGui.BeginDisabled();
-                if (ImGuiEx.ButtonCtrl($"Delete {filterCount}Filtered Macros", new Vector2(ImGui.GetContentRegionAvail().X / 2, ImGui.GetContentRegionAvail().Y)))
+                if (ImGuiEx.ButtonCtrl($"Delete {filterCount}Filtered Macro{(Table.FilteredItems.Count == 1 ? "" : "s")}", new Vector2(ImGui.GetContentRegionAvail().X / 2, ImGui.GetContentRegionAvail().Y)))
                 {
                     var toDelete = Table.FilteredItems.JSONClone();
                     foreach ((RaphaelOptions key, int _) in toDelete)

--- a/Artisan/UI/SimulatorUI.cs
+++ b/Artisan/UI/SimulatorUI.cs
@@ -568,11 +568,12 @@ namespace Artisan.UI
 
         private static void DrawSolverActions()
         {
-            if (_selectedSolver != null && (SimGS != null || CustomStatMode))
+            if (_selectedCraft != null && _selectedSolver != null && (SimGS != null || CustomStatMode))
             {
-                if (solverIsRaph && !RaphaelCache.HasSolution(_selectedCraft, out var _))
+                var raphConfig = RaphaelCache.GetRaphConfig(_selectedCraft, true);
+                if (solverIsRaph && !RaphaelCache.HasSolution(_selectedCraft, raphConfig, out var _))
                 {
-                    var key = RaphaelCache.GetKey(_selectedCraft);
+                    var key = RaphaelCache.GetOptions(_selectedCraft, raphConfig);
                     if (!RaphaelCache.Tasks.ContainsKey(key))
                     {
                         if (ImGui.Button("Generate Solution"))
@@ -580,8 +581,6 @@ namespace Artisan.UI
                             if (RaphaelCache.CLIExists())
                             {
                                 Svc.Log.Debug("Raphael set as config but has no solution, generating now...");
-                                var raphConfig = RaphaelCache.GetConfigFromTempOrDefault(_selectedCraft);
-
                                 RaphaelCache.Build(_selectedCraft, raphConfig);
                                 return; // wait for solution to be ready
                             }

--- a/Artisan/UI/Tables/RaphaelCacheTable.cs
+++ b/Artisan/UI/Tables/RaphaelCacheTable.cs
@@ -1,0 +1,277 @@
+﻿using Artisan.CraftingLogic.Solvers;
+using Artisan.RawInformation;
+using Dalamud.Bindings.ImGui;
+using ECommons.DalamudServices;
+using ECommons.ImGuiMethods;
+using OtterGui.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using TerraFX.Interop.Windows;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Artisan.UI.Tables
+{
+    // todo: ideally this would highlight the entire row as a single Selectable instead of every cell separately
+    internal class ClickableColumn : ColumnString<RaphaelOptions>
+    {
+        public override void DrawColumn(RaphaelOptions key, int _)
+        {
+            if (ImGui.Selectable(this.ToName(key)))
+            {
+                var m = P.Config.RaphaelSolverCacheV6[key];
+                if (!P.ws.Windows.Any(x => x.WindowName.Contains(m.ID.ToString())))
+                {
+                    new MacroEditor(m, true);
+                }
+            }
+        }
+    }
+
+    internal class RaphaelCacheTable : Table<RaphaelOptions>, IDisposable
+    {
+        private static float _colWidthLevel;
+        private static float _colWidthProgress;
+        private static float _colWidthQuality;
+        private static float _colWidthDurability;
+        private static float _colWidthCraftsmanship;
+        private static float _colWidthControl;
+        private static float _colWidthCP;
+        private static float _colWidthIsExpert;
+        private static float _colWidthInitialQuality;
+        private static float _colWidthSpecialist;
+        private static float _colWidthSteadyHands;
+        private static float _colWidthUseHeartAndSoul;
+        private static float _colWidthUseQuickInno;
+        private static float _colWidthHasManipulation;
+        private static float _colWidthEnsureReliability;
+        private static float _colWidthBackloadProgress;
+        private static float _scale;
+
+        public readonly LevelColumn _colLevel = new() { Label = "Level" };
+        public readonly ProgressColumn _colProgress = new() { Label = "Progress" };
+        public readonly QualityColumn _colQuality = new() { Label = "Quality" };
+        public readonly DurabilityColumn _colDurability = new() { Label = "Dura" };
+        public readonly CraftsmanshipColumn _colCraftsmanship = new() { Label = "Craftsmanship" };
+        public readonly ControlColumn _colControl = new() { Label = "Control" };
+        public readonly CPColumn _colCP = new() { Label = "CP" };
+        public readonly IsExpertColumn _colIsExpert = new() { Label = "Expert" };
+        public readonly InitialQualityColumn _colInitialQuality = new() { Label = "Init. Q" };
+        public readonly SpecialistColumn _colSpecialist = new() { Label = "Specialist" };
+        public readonly SteadyHandsColumn _colSteadyHands = new() { Label = "Steady" };
+        public readonly UseHeartAndSoulColumn _colUseHeartAndSoul = new() { Label = "H&S" };
+        public readonly UseQuickInnoColumn _colUseQuickInno = new() { Label = "QI" };
+        public readonly HasManipulationColumn _colHasManipulation = new() { Label = "Manip" };
+        public readonly EnsureReliabilityColumn _colEnsureReliability = new() { Label = "Ensure" };
+        public readonly BackloadProgressColumn _colBackloadProgress = new() { Label = "Backload" };
+
+        private static float TextWidth(string text) => ImGui.CalcTextSize(text).X + ImGui.GetStyle().ItemSpacing.X;
+
+        protected override void PreDraw()
+        {
+            if (_scale != ImGuiHelpers.GlobalScale)
+            {
+                _scale = ImGuiHelpers.GlobalScale;
+                _colWidthLevel = TextWidth(_colLevel.Label) / _scale + Table.ArrowWidth;
+                _colWidthProgress = TextWidth(_colProgress.Label) / _scale + Table.ArrowWidth;
+                _colWidthQuality = TextWidth(_colQuality.Label) / _scale + Table.ArrowWidth;
+                _colWidthDurability = TextWidth(_colDurability.Label) / _scale + Table.ArrowWidth;
+                _colWidthCraftsmanship = TextWidth(_colCraftsmanship.Label) / _scale + Table.ArrowWidth;
+                _colWidthControl = TextWidth(_colControl.Label) / _scale + Table.ArrowWidth;
+                _colWidthCP = Items.Max(i => TextWidth(i.MinCP.ToString())) / _scale + Table.ArrowWidth;
+                _colWidthIsExpert = TextWidth("Expert") / _scale + Table.ArrowWidth;
+                _colWidthInitialQuality = TextWidth(_colInitialQuality.Label) / _scale + Table.ArrowWidth;
+                _colWidthSpecialist = TextWidth("Yes") / _scale + Table.ArrowWidth;
+                _colWidthSteadyHands = TextWidth("0") / _scale + Table.ArrowWidth;
+                _colWidthUseHeartAndSoul = TextWidth("Yes") / _scale + Table.ArrowWidth;
+                _colWidthUseQuickInno = TextWidth("Yes") / _scale + Table.ArrowWidth;
+                _colWidthHasManipulation = TextWidth("Yes") / _scale + Table.ArrowWidth;
+                _colWidthEnsureReliability = TextWidth("Yes") / _scale + Table.ArrowWidth;
+                _colWidthBackloadProgress = TextWidth("Yes") / _scale + Table.ArrowWidth;
+            }
+        }
+
+        public RaphaelCacheTable(List<RaphaelOptions> cacheList) : base("RaphaelCacheTable", cacheList)
+        {
+            List<Column<RaphaelOptions>> headers = [_colLevel, _colProgress, _colQuality, _colDurability, _colCraftsmanship, _colControl, _colCP, _colIsExpert, _colInitialQuality, _colSpecialist, _colSteadyHands, _colUseHeartAndSoul, _colUseQuickInno, _colHasManipulation, _colEnsureReliability, _colBackloadProgress];
+            this.Headers = [.. headers];
+
+            Sortable = true;
+            Flags |= ImGuiTableFlags.Hideable | ImGuiTableFlags.Reorderable | ImGuiTableFlags.Resizable;
+        }
+
+        public void Dispose()
+        {
+
+        }
+
+        public void ClickableCell(RaphaelOptions key, string text)
+        {
+            if (ImGui.Selectable(text))
+            {
+                var m = P.Config.RaphaelSolverCacheV6[key];
+                if (!P.ws.Windows.Any(x => x.WindowName.Contains(m.ID.ToString())))
+                {
+                    new MacroEditor(m, true);
+                }
+            }
+        }
+
+        public sealed class LevelColumn : ClickableColumn
+        {
+            public LevelColumn() => Flags |= ImGuiTableColumnFlags.NoHide;
+
+            public override string ToName(RaphaelOptions m) => m.Level.ToString();
+            public override float Width => _colWidthLevel * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs) => lhs.Level.CompareTo(rhs.Level);
+    }
+
+        public sealed class ProgressColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.Progress.ToString();
+            public override float Width => _colWidthProgress * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs) => lhs.Progress.CompareTo(rhs.Progress);
+        }
+
+        public sealed class QualityColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.QualityMax.ToString();
+            public override float Width => _colWidthQuality * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.QualityMax - rhs.QualityMax;
+            }
+        }
+
+        public sealed class DurabilityColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.Durability.ToString();
+            public override float Width => _colWidthDurability * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.Durability - rhs.Durability;
+            }
+        }
+
+        public sealed class CraftsmanshipColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.MinCraftsmanship.ToString();
+            public override float Width => _colWidthCraftsmanship * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.MinCraftsmanship - rhs.MinCraftsmanship;
+            }
+        }
+
+        public sealed class ControlColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.MinControl.ToString();
+            public override float Width => _colWidthControl * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.MinControl - rhs.MinControl;
+            }
+        }
+
+        public sealed class CPColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.MinCP.ToString();
+            public override float Width => _colWidthCP * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.MinCP - rhs.MinCP;
+            }
+        }
+
+        public sealed class IsExpertColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.IsExpert ? "Expert" : "";
+            public override float Width => _colWidthIsExpert * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.IsExpert && !rhs.IsExpert ? -1 : !lhs.IsExpert && rhs.IsExpert ? 1 : 0;
+            }
+        }
+
+        public sealed class InitialQualityColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.InitialQuality.ToString();
+            public override float Width => _colWidthInitialQuality * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.InitialQuality - rhs.InitialQuality;
+            }
+        }
+
+        public sealed class SpecialistColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.IsSpecialist.ToString();
+            public override float Width => _colWidthSpecialist * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.IsSpecialist && !rhs.IsSpecialist ? -1 : !lhs.IsSpecialist && rhs.IsSpecialist ? 1 : 0;
+            }
+        }
+
+        public sealed class SteadyHandsColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.SteadyHandUses.ToString();
+            public override float Width => _colWidthSteadyHands * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.SteadyHandUses - rhs.SteadyHandUses;
+            }
+        }
+
+        public sealed class UseHeartAndSoulColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.SolutionConfig.UseHeartAndSoul.ToString();
+            public override float Width => _colWidthUseHeartAndSoul * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.SolutionConfig.UseHeartAndSoul && !rhs.SolutionConfig.UseHeartAndSoul ? -1 : !lhs.SolutionConfig.UseHeartAndSoul && rhs.SolutionConfig.UseHeartAndSoul ? 1 : 0;
+            }
+        }
+
+        public sealed class UseQuickInnoColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.SolutionConfig.UseQuickInno.ToString();
+            public override float Width => _colWidthUseQuickInno * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.SolutionConfig.UseQuickInno && !rhs.SolutionConfig.UseQuickInno ? -1 : !lhs.SolutionConfig.UseQuickInno && rhs.SolutionConfig.UseQuickInno ? 1 : 0;
+            }
+        }
+
+        public sealed class HasManipulationColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.SolutionConfig.HasManipulation.ToString();
+            public override float Width => _colWidthHasManipulation * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.SolutionConfig.HasManipulation && !rhs.SolutionConfig.HasManipulation ? -1 : !lhs.SolutionConfig.HasManipulation && rhs.SolutionConfig.HasManipulation ? 1 : 0;
+            }
+        }
+
+        public sealed class EnsureReliabilityColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.SolutionConfig.EnsureReliability.ToString();
+            public override float Width => _colWidthEnsureReliability * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.SolutionConfig.EnsureReliability && !rhs.SolutionConfig.EnsureReliability ? -1 : !lhs.SolutionConfig.EnsureReliability && rhs.SolutionConfig.EnsureReliability ? 1 : 0;
+            }
+        }
+
+        public sealed class BackloadProgressColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => m.SolutionConfig.BackloadProgress.ToString();
+            public override float Width => _colWidthBackloadProgress * ImGuiHelpers.GlobalScale;
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return lhs.SolutionConfig.BackloadProgress && !rhs.SolutionConfig.BackloadProgress ? -1 : !lhs.SolutionConfig.BackloadProgress && rhs.SolutionConfig.BackloadProgress ? 1 : 0;
+            }
+        }
+    }
+}

--- a/Artisan/UI/Tables/RaphaelCacheTable.cs
+++ b/Artisan/UI/Tables/RaphaelCacheTable.cs
@@ -47,24 +47,26 @@ namespace Artisan.UI.Tables
         private static float _colWidthHasManipulation;
         private static float _colWidthEnsureReliability;
         private static float _colWidthBackloadProgress;
+        private static float _colWidthMacroSteps;
         private static float _scale;
 
         public readonly LevelColumn _colLevel = new() { Label = "Level" };
         public readonly ProgressColumn _colProgress = new() { Label = "Progress" };
         public readonly QualityColumn _colQuality = new() { Label = "Quality" };
-        public readonly DurabilityColumn _colDurability = new() { Label = "Dura" };
+        public readonly DurabilityColumn _colDurability = new() { Label = "Durability" };
         public readonly CraftsmanshipColumn _colCraftsmanship = new() { Label = "Craftsmanship" };
         public readonly ControlColumn _colControl = new() { Label = "Control" };
         public readonly CPColumn _colCP = new() { Label = "CP" };
         public readonly IsExpertColumn _colIsExpert = new() { Label = "Expert" };
-        public readonly InitialQualityColumn _colInitialQuality = new() { Label = "Init. Q" };
+        public readonly InitialQualityColumn _colInitialQuality = new() { Label = "Initial Quality" };
         public readonly SpecialistColumn _colSpecialist = new() { Label = "Specialist" };
-        public readonly SteadyHandsColumn _colSteadyHands = new() { Label = "Steady" };
-        public readonly UseHeartAndSoulColumn _colUseHeartAndSoul = new() { Label = "H&S" };
-        public readonly UseQuickInnoColumn _colUseQuickInno = new() { Label = "QI" };
-        public readonly HasManipulationColumn _colHasManipulation = new() { Label = "Manip" };
-        public readonly EnsureReliabilityColumn _colEnsureReliability = new() { Label = "Ensure" };
-        public readonly BackloadProgressColumn _colBackloadProgress = new() { Label = "Backload" };
+        public readonly SteadyHandsColumn _colSteadyHands = new() { Label = "Steady Hand" };
+        public readonly UseHeartAndSoulColumn _colUseHeartAndSoul = new() { Label = "Heart & Soul" };
+        public readonly UseQuickInnoColumn _colUseQuickInno = new() { Label = "Quick Innovation" };
+        public readonly HasManipulationColumn _colHasManipulation = new() { Label = "Manipulation" };
+        public readonly EnsureReliabilityColumn _colEnsureReliability = new() { Label = "Ensure Reliability" };
+        public readonly BackloadProgressColumn _colBackloadProgress = new() { Label = "Backload Progress" };
+        public readonly MacroStepColumn _colMacroStep = new() { Label = "Macro Step Count" };
 
         private static float TextWidth(string text) => ImGui.CalcTextSize(text).X + ImGui.GetStyle().ItemSpacing.X;
 
@@ -89,12 +91,13 @@ namespace Artisan.UI.Tables
                 _colWidthHasManipulation = TextWidth("Yes") / _scale + Table.ArrowWidth;
                 _colWidthEnsureReliability = TextWidth("Yes") / _scale + Table.ArrowWidth;
                 _colWidthBackloadProgress = TextWidth("Yes") / _scale + Table.ArrowWidth;
+                _colWidthMacroSteps = TextWidth(_colMacroStep.Label) / _scale + Table.ArrowWidth;
             }
         }
 
         public RaphaelCacheTable(List<RaphaelOptions> cacheList) : base("RaphaelCacheTable", cacheList)
         {
-            List<Column<RaphaelOptions>> headers = [_colLevel, _colProgress, _colQuality, _colDurability, _colCraftsmanship, _colControl, _colCP, _colIsExpert, _colInitialQuality, _colSpecialist, _colSteadyHands, _colUseHeartAndSoul, _colUseQuickInno, _colHasManipulation, _colEnsureReliability, _colBackloadProgress];
+            List<Column<RaphaelOptions>> headers = [_colLevel, _colProgress, _colQuality, _colDurability, _colCraftsmanship, _colControl, _colCP, _colIsExpert, _colInitialQuality, _colSpecialist, _colSteadyHands, _colUseHeartAndSoul, _colUseQuickInno, _colHasManipulation, _colEnsureReliability, _colBackloadProgress, _colMacroStep];
             this.Headers = [.. headers];
 
             Sortable = true;
@@ -186,7 +189,7 @@ namespace Artisan.UI.Tables
 
         public sealed class IsExpertColumn : ClickableColumn
         {
-            public override string ToName(RaphaelOptions m) => m.IsExpert ? "Expert" : "";
+            public override string ToName(RaphaelOptions m) => m.IsExpert ? "Yes" : "No";
             public override float Width => _colWidthIsExpert * ImGuiHelpers.GlobalScale;
             public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
             {
@@ -271,6 +274,18 @@ namespace Artisan.UI.Tables
             public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
             {
                 return lhs.SolutionConfig.BackloadProgress && !rhs.SolutionConfig.BackloadProgress ? -1 : !lhs.SolutionConfig.BackloadProgress && rhs.SolutionConfig.BackloadProgress ? 1 : 0;
+            }
+        }
+
+        public sealed class MacroStepColumn : ClickableColumn
+        {
+            public override string ToName(RaphaelOptions m) => P.Config.RaphaelSolverCacheV6[m].Steps.Count().ToString();
+
+            public override float Width => _colWidthMacroSteps * ImGuiHelpers.GlobalScale;
+
+            public override int Compare(RaphaelOptions lhs, RaphaelOptions rhs)
+            {
+                return P.Config.RaphaelSolverCacheV6[lhs].Steps.Count() - P.Config.RaphaelSolverCacheV6[rhs].Steps.Count();
             }
         }
     }


### PR DESCRIPTION
Copied from Discord:

Here's the big changes:

* Raph cache is now its own file
* Raph cache entries are keyed by the full options dict (recipe stats + expert/specialist/etc + macro generation options) instead of the combined strings
* As part of that, cache entries are now unique to all generation settings; for example, a specific recipe stat line can now have separate Raph macros with/without backload progress, ensure reliability, etc.
* Whether you have Manipulation unlocked is now part of the cache key too
* New cache UI using an OtterGui table to let you sort, filter, etc. each column separately
* I have logic in place to automatically convert the v5 cache to the new v6 cache. For the fields that weren't tracked in v5 I used the following logic:
  * "Backload progress" is enabled if the existing macro has no quality actions after its final progress action
  * "Use Heart & Soul/Quick Innovation" are enabled if the existing macro has the appropriate action as a step
  * "Ensure reliability" is disabled across the board, just to make sure. Better to regenerate with the option enabled than to assume
  * It assumes you have manipulation for a given macro if it uses manip in any step OR you have manip unlocked on all jobs, otherwise it assumes you don't _(this is the biggest potential issue, but worst case people without manip on all jobs will just have to regenerate some macros)_
* The v5 cache is kept in the config file after conversion but won't be loaded; this is just for backup purposes. We can delete it in the future to make the config file smaller if you want. Alternately I could write it out to a separate v5 backup file
* You can no longer view the v4 cache because it's been deprecated for a long time, should be ok?