### PR TITLE
Added MacroInfo IPC

### DIFF
--- a/Artisan/IPC/IPC.cs
+++ b/Artisan/IPC/IPC.cs
@@ -86,6 +86,8 @@ namespace Artisan.IPC
 
             Svc.PluginInterface.GetIpcProvider<uint, bool, object>("Artisan.ChangeStandardMinimumStepsBeforeMiracle").RegisterAction(ChangeStandardMinimumStepsBeforeMiracle);
             Svc.PluginInterface.GetIpcProvider<object>("Artisan.SetTempStandardMinimumStepsBeforeMiracleBackToNormal").RegisterAction(SetTempStandardMinimumStepsBeforeMiracleBackToNormal);
+
+            Svc.PluginInterface.GetIpcProvider<List<(string, int)>>("Artisan.ReturnMacroInfo").RegisterFunc(ReturnMacroInfo);
         }
 
         internal static void Dispose()
@@ -141,6 +143,8 @@ namespace Artisan.IPC
 
             Svc.PluginInterface.GetIpcProvider<uint, bool, object>("Artisan.ChangeStandardMinimumStepsBeforeMiracle").UnregisterAction();
             Svc.PluginInterface.GetIpcProvider<object>("Artisan.SetTempStandardMinimumStepsBeforeMiracleBackToNormal").UnregisterAction();
+
+            Svc.PluginInterface.GetIpcProvider<List<(string, uint)>>("Artisan.ReturnMacroInfo").UnregisterFunc();
         }
 
         static bool GetEnduranceStatus()
@@ -609,6 +613,24 @@ namespace Artisan.IPC
         {
             if (P.Config.TempMinimumStepsBeforeMiracle != null)
                 P.Config.TempMinimumStepsBeforeMiracle = null;
+        }
+
+        /// <summary>
+        /// Returns a list of all currently existing macro's, with the Id + Name attached to them. 
+        /// </summary>
+        /// <returns></returns>
+        public static List<(string, int)> ReturnMacroInfo()
+        {
+            List<(string, int)> macros = new();
+
+            var macroList = P.Config.MacroSolverConfig.Macros;
+            if (macroList.Count > 0)
+            {
+                foreach (var macro in macroList)
+                    macros.Add(new(macro.Name, macro.ID));
+            }
+
+            return macros;
         }
 
         public enum ArtisanMode


### PR DESCRIPTION
- Added an IPC method to return the Names + ID of all currently existing macro's in artisan. This is moreso for Cosmic usage since users can set macro names directly in the plugin (and honestly to save a bit of headache on my part)