### PR TITLE
Let Raphael solve for the recipe's true maximum quality

### DIFF
--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -368,6 +368,9 @@ namespace Artisan.CraftingLogic.Solvers
         // the quality the solver is asked to reach; anything above it is wasted CP, so the thresholds below are the point at which the reward stops improving
         public static int GetTargetQuality(CraftState craft)
         {
+            if (P.Config.RaphaelSolverConfig.TargetMaxQuality)
+                return craft.CraftQualityMax;
+
             if (craft.CraftCollectible && !craft.IsCosmic)
                 return craft.CraftQualityMin3;
 
@@ -768,6 +771,7 @@ namespace Artisan.CraftingLogic.Solvers
         public bool GenerateOnExperts = false;
         public int TimeOutMins = 1;
         public int MaxStellarHand = 2;
+        public bool TargetMaxQuality = false;
         public bool DefaultRaphSolver = false;
         public bool FallbackToSolverIfRaphaelLocked = true;
         public string FallbackSolverType = typeof(StandardSolverDefinition).FullName!;
@@ -841,6 +845,9 @@ namespace Artisan.CraftingLogic.Solvers
 
                 changed |= ImGui.Checkbox("Allow specialist actions when available", ref ShowSpecialistSettings);
                 ImGuiComponents.HelpMarker($"Enables checkboxes on the Crafting Log mini-menu that let the solver use {Skills.HeartAndSoul.NameOfAction()} and {Skills.QuickInnovation.NameOfAction()}.");
+
+                changed |= ImGui.Checkbox("Always solve for maximum quality", ref TargetMaxQuality);
+                ImGuiComponents.HelpMarker($"By default a collectable is solved to its highest collectability tier, the point where {QualityString.ToLower()} stops paying. Enable this to solve for the recipe's true maximum instead: a longer macro costing more CP, for no extra reward in game.");
 
                 changed |= P.PluginUi.ExpertSettingsUI.SliderIntWithIcons("MaxStellarHand", ref MaxStellarHand, 0, 2, "Max [s!SteadyHand] uses per craft");
                 P.PluginUi.ExpertSettingsUI.HelpMarkerWithIcons(["This setting only applies to Cosmic Exploration recipes on missions with [s!SteadyHand].", "The Raphael solver will use UP TO this many charges depending on the recipe's difficulty."]);

--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -81,11 +81,12 @@ namespace Artisan.CraftingLogic.Solvers
             CurrentCache.TryRemove(key, out _);
 
             var manipulation = config.HasManipulation ? "--manipulation" : "";
-            var itemText = $"--custom-recipe {craft.LevelTable.RowId} {craft.CraftProgress} {(craft.CraftCollectible && !craft.IsCosmic ? craft.CraftQualityMin3 : craft.CraftQualityMax)} {craft.CraftDurability} {(craft.CraftExpert ? "1" : "0")} --stellar-steady-hand {Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}";
+            var itemText = $"--custom-recipe {craft.LevelTable.RowId} {craft.CraftProgress} {craft.CraftQualityMax} {craft.CraftDurability} {(craft.CraftExpert ? "1" : "0")} --stellar-steady-hand {Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}";
 
             var argsList = new List<string>
             {
-                $"--initial {craft.InitialQuality}"
+                $"--initial {craft.InitialQuality}",
+                $"--target-quality {GetTargetQuality(craft)}"
             };
 
             if (config.EnsureReliability) argsList.Add("--adversarial");
@@ -360,6 +361,18 @@ namespace Artisan.CraftingLogic.Solvers
                 UseHeartAndSoul = globalRaph.ShowSpecialistSettings && globalRaph.UseHeartAndSoul && craft.Specialist && (!checkDelins || hasDelins),
                 UseQuickInno = globalRaph.ShowSpecialistSettings && globalRaph.UseQuickInno && craft.Specialist && (!checkDelins || hasDelins),
             };
+        }
+
+        // the quality the solver is asked to reach; anything above it is wasted CP, so the thresholds below are the point at which the reward stops improving
+        public static int GetTargetQuality(CraftState craft)
+        {
+            if (craft.CraftCollectible && !craft.IsCosmic)
+                return craft.CraftQualityMin3;
+
+            if (craft.CraftRequiredQuality > 0)
+                return craft.CraftRequiredQuality;
+
+            return craft.CraftQualityMax;
         }
 
         public static bool HasSolution(CraftState craft, out Macro? raphaelSolution) => HasSolution(craft, null, out raphaelSolution);

--- a/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
+++ b/Artisan/CraftingLogic/Solvers/RaphaelSolver.cs
@@ -191,6 +191,7 @@ namespace Artisan.CraftingLogic.Solvers
                                 StatLevel = craft.StatLevel,
                                 Progress = craft.CraftProgress,
                                 QualityMax = craft.CraftQualityMax,
+                                TargetQuality = GetTargetQuality(craft),
                                 Durability = craft.CraftDurability,
                                 IsExpert = craft.CraftExpert,
                                 InitialQuality = craft.InitialQuality,
@@ -314,6 +315,7 @@ namespace Artisan.CraftingLogic.Solvers
                 StatLevel = craft.StatLevel,
                 Progress = craft.CraftProgress,
                 QualityMax = craft.CraftQualityMax,
+                TargetQuality = GetTargetQuality(craft),
                 Durability = craft.CraftDurability,
                 IsExpert = craft.CraftExpert,
                 InitialQuality = craft.InitialQuality,
@@ -326,12 +328,12 @@ namespace Artisan.CraftingLogic.Solvers
         // this key is for identifying solutions while debugging; code should look up solutions by their RaphaelOptions
         public static string GetTextKey(CraftState craft, RaphaelSolutionConfig config)
         {
-            return $"{craft.CraftLevel}/{craft.CraftProgress}/{craft.CraftQualityMax}/{craft.CraftDurability}-{craft.StatCraftsmanship}/{craft.StatControl}/{craft.StatCP}-{(craft.CraftExpert ? "Ex" : "St")}/{craft.InitialQuality}/{(craft.Specialist ? "Sp" : "Re")}/Steady{Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}-{(config.UseHeartAndSoul ? "1" : "0")}/{(config.UseQuickInno ? "1" : "0")}/{(config.HasManipulation ? "1" : "0")}/{(config.EnsureReliability ? "1" : "0")}/{(config.BackloadProgress ? "1" : "0")}";
+            return $"{craft.CraftLevel}/{craft.CraftProgress}/{craft.CraftQualityMax}/{GetTargetQuality(craft)}/{craft.CraftDurability}-{craft.StatCraftsmanship}/{craft.StatControl}/{craft.StatCP}-{(craft.CraftExpert ? "Ex" : "St")}/{craft.InitialQuality}/{(craft.Specialist ? "Sp" : "Re")}/Steady{Math.Min(craft.CurrentSteadyHandCharges, P.Config.RaphaelSolverConfig.MaxStellarHand)}-{(config.UseHeartAndSoul ? "1" : "0")}/{(config.UseQuickInno ? "1" : "0")}/{(config.HasManipulation ? "1" : "0")}/{(config.EnsureReliability ? "1" : "0")}/{(config.BackloadProgress ? "1" : "0")}";
         }
 
         public static string GetKeyForLookups(RaphaelOptions opt)
         {
-            return $"{opt.Level}/{opt.Progress}/{opt.QualityMax}/{opt.Durability}-{opt.MinCraftsmanship}/{opt.MinControl}/{opt.MinCP}-{(opt.IsExpert ? "Ex" : "St")}/{opt.InitialQuality}/{(opt.IsSpecialist ? "Sp" : "Re")}/Steady{opt.SteadyHandUses}-{(opt.SolutionConfig.UseHeartAndSoul ? "1" : "0")}/{(opt.SolutionConfig.UseQuickInno ? "1" : "0")}/{(opt.SolutionConfig.HasManipulation ? "1" : "0")}/{(opt.SolutionConfig.EnsureReliability ? "1" : "0")}/{(opt.SolutionConfig.BackloadProgress ? "1" : "0")}";
+            return $"{opt.Level}/{opt.Progress}/{opt.QualityMax}/{opt.TargetQuality}/{opt.Durability}-{opt.MinCraftsmanship}/{opt.MinControl}/{opt.MinCP}-{(opt.IsExpert ? "Ex" : "St")}/{opt.InitialQuality}/{(opt.IsSpecialist ? "Sp" : "Re")}/Steady{opt.SteadyHandUses}-{(opt.SolutionConfig.UseHeartAndSoul ? "1" : "0")}/{(opt.SolutionConfig.UseQuickInno ? "1" : "0")}/{(opt.SolutionConfig.HasManipulation ? "1" : "0")}/{(opt.SolutionConfig.EnsureReliability ? "1" : "0")}/{(opt.SolutionConfig.BackloadProgress ? "1" : "0")}";
         }
 
         public static IEnumerable<CraftState> AllValidCrafts(RaphaelOptions key)
@@ -914,6 +916,7 @@ namespace Artisan.CraftingLogic.Solvers
         public int StatLevel = 0;
         public int Progress = 0;
         public int QualityMax = 0;
+        public int TargetQuality = 0;
         public int Durability = 0;
         public bool IsExpert = false;
         public int InitialQuality = 0;


### PR DESCRIPTION
Artisan smuggles the solver's quality goal in through the QUALITY slot of `--custom-recipe`. That slot is raphael's `max_quality_override`: it states what the recipe's maximum quality *is*, not what to aim for. For collectables it is set to the tier 3 collectability threshold, so raphael is told the recipe cannot exceed tier 3 at all, and there is no way to ask it for anything else.

Measured against the pinned CLI, same recipe and stats:

```
target 9000  (tier 3) → final_quality 9175,  17 steps
target 14040 (max)    → final_quality 13661, 29 steps
```

CP is not the constraint — sweeping CP at the max target gives 13661 @ 630 CP and 14109 @ 700 CP. The solver spends everything it has once it is asked for the real target.

Three commits:

1. **Express Raphael's quality goal with `--target-quality`.** Pure refactor. Pass the recipe's real maximum in `--custom-recipe` and state the goal with the CLI's own flag, which has existed since well before the revision this repo pins. `GetTargetQuality` returns exactly the values that were passed before, so solutions are unchanged: verified against the pinned CLI, where both forms produce an identical action list and final quality, differing only in the `recipe_max_quality` they report.

2. **Include the quality target in the cache key.** Two solutions for the same recipe at different targets are different solutions. `RaphaelOptions` is serialised whole as the key string in `RaphaelCache.dat`, so existing entries deserialise with `TargetQuality == 0`, miss, and regenerate once — deliberate, since a stale entry cannot be shown to have been solved for the target it is being looked up under.

3. **Add a setting to solve collectables for maximum quality**, off by default. Leaving it off keeps today's behaviour exactly: quality above a collectable's tier 3 buys nothing in game, and asking for it produces a longer macro that spends more CP for the same reward. Enabling it targets the recipe's true maximum. Solutions made with the setting on and off cache separately, so toggling it does not invalidate either. Recipes with a required quality are unaffected by the setting, since building the craft state overwrites their `CraftQualityMax` with the required quality — maximum and threshold are already the same number.

No change to `raphael-cli.bin` is needed — both `--target-quality` and the output variables used here already exist in the committed binary.

Compiles clean (Release, 0 errors). Not tested in game — I develop on macOS; the raphael-cli behaviour above was verified against a locally built copy of the pinned revision.

Touches the same file as #296 and will need a trivial rebase depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)